### PR TITLE
refactor: replace sqlx with rusqlite, add CI/CD and Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# Build artifacts
+target/
+debug/
+release/
+
+# Cargo
+.cargo/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Environment
+.env
+.env.*
+!.env.example
+
+# Database
+*.sqlite3
+*.db
+
+# Git
+.git/
+.gitignore
+
+# Documentation
+*.md
+!README.md
+
+# CI/CD
+.github/
+
+# Misc
+Dockerfile
+.dockerignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [main, feature/*]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy
+        run: cargo clippy -- -D warnings
+
+      - name: Build
+        run: cargo build --verbose
+
+      - name: Run tests
+        run: cargo test --verbose

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,44 @@
+name: Docker
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,12 +22,6 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -111,15 +117,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atoi"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +185,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c794b30c904f0a1c2fb7740f7df7f7972dfaa14ef6f57cb6178dc63e5dca2f04"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "cookie",
+ "fastrand",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "multer",
+ "pin-project-lite",
+ "serde",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "axum-macros"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,9 +245,6 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "blake2"
@@ -251,12 +269,6 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -295,27 +307,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
+ "base64",
+ "hmac",
  "percent-encoding",
+ "rand 0.8.5",
+ "sha2",
+ "subtle",
  "time",
  "version_check",
 ]
@@ -334,36 +336,6 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "crc"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
-dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -411,24 +383,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
- "serde_core",
 ]
 
 [[package]]
@@ -438,7 +398,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
- "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -461,19 +420,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
-name = "either"
-version = "1.15.0"
+name = "encoding_rs"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
- "serde",
+ "cfg-if",
 ]
-
-[[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -486,26 +439,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "etcetera"
-version = "0.8.0"
+name = "fallible-iterator"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
-dependencies = [
- "cfg-if",
- "home",
- "windows-sys 0.48.0",
-]
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
-name = "event-listener"
-version = "5.4.1"
+name = "fallible-streaming-iterator"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
@@ -514,27 +463,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
-name = "flume"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
-dependencies = [
- "futures-core",
- "futures-sink",
- "spin",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -546,27 +478,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -574,45 +491,6 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-intrusive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
-dependencies = [
- "futures-core",
- "lock_api",
- "parking_lot",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
 
 [[package]]
 name = "futures-sink"
@@ -633,14 +511,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -678,49 +551,20 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
+ "ahash",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac",
+ "hashbrown",
 ]
 
 [[package]]
@@ -730,15 +574,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
-]
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -981,16 +816,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "2.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
-dependencies = [
- "equivalent",
- "hashbrown 0.16.1",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,9 +836,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "libc"
@@ -1026,17 +848,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "libredox"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
-dependencies = [
- "bitflags",
- "libc",
- "redox_syscall 0.7.0",
-]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1058,19 +869,21 @@ dependencies = [
  "askama",
  "askama_axum",
  "axum",
+ "axum-extra",
  "chrono",
  "dotenvy",
- "rand",
+ "r2d2",
+ "r2d2_sqlite",
+ "rand 0.8.5",
+ "rusqlite",
  "serde",
- "sqlx",
- "thiserror 1.0.69",
+ "serde_json",
+ "thiserror",
  "time",
  "tokio",
  "tokio-test",
  "tower 0.4.13",
  "tower-http",
- "tower-sessions",
- "tower-sessions-sqlx-store",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -1090,7 +903,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
- "serde",
 ]
 
 [[package]]
@@ -1113,16 +925,6 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest",
-]
 
 [[package]]
 name = "memchr"
@@ -1164,6 +966,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,46 +1002,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
 
 [[package]]
 name = "num-traits"
@@ -1231,7 +1014,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -1239,12 +1021,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1264,7 +1040,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -1276,17 +1052,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -1326,27 +1093,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
 
 [[package]]
 name = "pkg-config"
@@ -1427,14 +1173,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r2d2"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
+]
+
+[[package]]
+name = "r2d2_sqlite"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb14dba8247a6a15b7fdbc7d389e2e6f03ee9f184f87117706d509c092dfe846"
+dependencies = [
+ "r2d2",
+ "rusqlite",
+ "uuid",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1444,7 +1222,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1457,19 +1245,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
+name = "rand_core"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "bitflags",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.0"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
@@ -1504,42 +1292,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
-name = "rmp"
-version = "0.8.15"
+name = "rusqlite"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "rmp-serde"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
-dependencies = [
- "rmp",
- "serde",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid",
- "digest",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core",
- "signature",
- "spki",
- "subtle",
- "zeroize",
+ "bitflags",
+ "chrono",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -1553,6 +1317,15 @@ name = "ryu"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
+dependencies = [
+ "parking_lot",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1627,17 +1400,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1674,29 +1436,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest",
- "rand_core",
-]
-
-[[package]]
-name = "slab"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
-
-[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "socket2"
@@ -1713,236 +1456,12 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
-name = "sqlx"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
-dependencies = [
- "sqlx-core",
- "sqlx-macros",
- "sqlx-mysql",
- "sqlx-postgres",
- "sqlx-sqlite",
-]
-
-[[package]]
-name = "sqlx-core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
-dependencies = [
- "base64",
- "bytes",
- "chrono",
- "crc",
- "crossbeam-queue",
- "either",
- "event-listener",
- "futures-core",
- "futures-intrusive",
- "futures-io",
- "futures-util",
- "hashbrown 0.15.5",
- "hashlink",
- "indexmap",
- "log",
- "memchr",
- "once_cell",
- "percent-encoding",
- "serde",
- "serde_json",
- "sha2",
- "smallvec",
- "thiserror 2.0.18",
- "time",
- "tokio",
- "tokio-stream",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "sqlx-macros"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
-dependencies = [
- "proc-macro2",
- "quote",
- "sqlx-core",
- "sqlx-macros-core",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "sqlx-macros-core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
-dependencies = [
- "dotenvy",
- "either",
- "heck",
- "hex",
- "once_cell",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "sha2",
- "sqlx-core",
- "sqlx-mysql",
- "sqlx-postgres",
- "sqlx-sqlite",
- "syn 2.0.114",
- "tokio",
- "url",
-]
-
-[[package]]
-name = "sqlx-mysql"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
-dependencies = [
- "atoi",
- "base64",
- "bitflags",
- "byteorder",
- "bytes",
- "chrono",
- "crc",
- "digest",
- "dotenvy",
- "either",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-util",
- "generic-array",
- "hex",
- "hkdf",
- "hmac",
- "itoa",
- "log",
- "md-5",
- "memchr",
- "once_cell",
- "percent-encoding",
- "rand",
- "rsa",
- "serde",
- "sha1",
- "sha2",
- "smallvec",
- "sqlx-core",
- "stringprep",
- "thiserror 2.0.18",
- "time",
- "tracing",
- "uuid",
- "whoami",
-]
-
-[[package]]
-name = "sqlx-postgres"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
-dependencies = [
- "atoi",
- "base64",
- "bitflags",
- "byteorder",
- "chrono",
- "crc",
- "dotenvy",
- "etcetera",
- "futures-channel",
- "futures-core",
- "futures-util",
- "hex",
- "hkdf",
- "hmac",
- "home",
- "itoa",
- "log",
- "md-5",
- "memchr",
- "once_cell",
- "rand",
- "serde",
- "serde_json",
- "sha2",
- "smallvec",
- "sqlx-core",
- "stringprep",
- "thiserror 2.0.18",
- "time",
- "tracing",
- "uuid",
- "whoami",
-]
-
-[[package]]
-name = "sqlx-sqlite"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
-dependencies = [
- "atoi",
- "chrono",
- "flume",
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-intrusive",
- "futures-util",
- "libsqlite3-sys",
- "log",
- "percent-encoding",
- "serde",
- "serde_urlencoded",
- "sqlx-core",
- "thiserror 2.0.18",
- "time",
- "tracing",
- "url",
- "uuid",
-]
 
 [[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "stringprep"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
- "unicode-properties",
-]
 
 [[package]]
 name = "strsim"
@@ -2000,16 +1519,7 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
-dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2017,17 +1527,6 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2194,23 +1693,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-cookies"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fd0118512cf0b3768f7fcccf0bef1ae41d68f2b45edc1e77432b36c97c56c6d"
-dependencies = [
- "async-trait",
- "axum-core",
- "cookie",
- "futures-util",
- "http",
- "parking_lot",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "tower-http"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,71 +1728,6 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
-
-[[package]]
-name = "tower-sessions"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65856c81ee244e0f8a55ab0f7b769b72fbde387c235f0a73cd97c579818d05eb"
-dependencies = [
- "async-trait",
- "http",
- "time",
- "tokio",
- "tower-cookies",
- "tower-layer",
- "tower-service",
- "tower-sessions-core",
- "tower-sessions-memory-store",
- "tracing",
-]
-
-[[package]]
-name = "tower-sessions-core"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb6abbfcaf6436ec5a772cd9f965401da12db793e404ae6134eac066fa5a04f3"
-dependencies = [
- "async-trait",
- "axum-core",
- "base64",
- "futures",
- "http",
- "parking_lot",
- "rand",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "time",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "tower-sessions-memory-store"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fad75660c8afbe74f4e7cbbe8e9090171a056b57370ea4d7d5e9eb3e4af3092"
-dependencies = [
- "async-trait",
- "time",
- "tokio",
- "tower-sessions-core",
-]
-
-[[package]]
-name = "tower-sessions-sqlx-store"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd38eba51214e99accab78f6b7c8e273e90a9cb57575e86b592c60074e182d7"
-dependencies = [
- "async-trait",
- "rmp-serde",
- "sqlx",
- "thiserror 1.0.69",
- "time",
- "tower-sessions-core",
-]
 
 [[package]]
 name = "tracing"
@@ -2408,12 +1825,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-properties"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,6 +1850,7 @@ checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
+ "rand 0.9.2",
  "serde_core",
  "wasm-bindgen",
 ]
@@ -2507,12 +1919,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2555,16 +1961,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "whoami"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite",
 ]
 
 [[package]]
@@ -2628,20 +2024,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2655,41 +2042,20 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2699,21 +2065,9 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2729,21 +2083,9 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2753,21 +2095,9 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2850,12 +2180,6 @@ dependencies = [
  "syn 2.0.114",
  "synstructure",
 ]
-
-[[package]]
-name = "zeroize"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,13 @@ tokio = { version = "1", features = ["full"] }
 askama = "0.12"
 askama_axum = "0.4"
 time = "0.3"
-sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "uuid", "chrono", "migrate"] }
-tower-sessions = "0.13"
-tower-sessions-sqlx-store = { version = "0.14", features = ["sqlite"] }
+rusqlite = { version = "0.32", features = ["bundled", "chrono"] }
+r2d2 = "0.8"
+r2d2_sqlite = "0.25"
+axum-extra = { version = "0.9", features = ["cookie-signed"] }
 argon2 = "0.5"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 validator = { version = "0.18", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Stage 1: Chef - prepare recipe
+FROM rust:1-bookworm AS chef
+RUN cargo install cargo-chef
+WORKDIR /app
+
+# Stage 2: Planner - create recipe.json
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# Stage 3: Builder - build dependencies then app
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+COPY . .
+RUN cargo build --release
+
+# Stage 4: Runtime
+FROM gcr.io/distroless/cc-debian12
+
+COPY --from=builder /app/target/release/liftlog /liftlog
+
+VOLUME /data
+
+ENV DATABASE_URL=/data/liftlog.sqlite3
+ENV SERVER_PORT=3000
+
+EXPOSE 3000
+
+ENTRYPOINT ["/liftlog"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,113 @@
+# LiftLog
+
+A self-hosted workout logging application built with Rust. Track your training sessions, monitor progress, and celebrate personal records.
+
+## Features
+
+- **Workout Tracking** - Log training sessions with exercises, sets, reps, and weight
+- **RPE Support** - Record Rate of Perceived Exertion (1-10) for each set
+- **Personal Records** - Automatic PR detection and tracking
+- **Exercise Library** - Manage your custom exercise database
+- **Statistics** - View workout history and progress per exercise
+- **Multi-User** - Support for multiple users with authentication
+- **Docker Ready** - Container image for easy deployment
+
+## Quick Start
+
+### Using Docker (Recommended)
+
+```bash
+docker run -d \
+  --name liftlog \
+  -p 3000:3000 \
+  -v liftlog_data:/data \
+  ghcr.io/henry40408/liftlog:latest
+```
+
+Visit `http://localhost:3000` and create your account.
+
+### Building from Source
+
+```bash
+# Clone repository
+git clone https://github.com/henry40408/liftlog.git
+cd liftlog
+
+# Build release binary
+cargo build --release
+
+# Run server
+./target/release/liftlog
+```
+
+## Configuration
+
+All configuration is done via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DATABASE_URL` | `sqlite:liftlog.sqlite3?mode=rwc` | SQLite database connection string |
+| `HOST` | `127.0.0.1` | Server bind address |
+| `PORT` | `3000` | HTTP server port |
+
+## Docker
+
+### Docker Compose
+
+```yaml
+services:
+  liftlog:
+    image: ghcr.io/henry40408/liftlog:latest
+    ports:
+      - "3000:3000"
+    volumes:
+      - liftlog_data:/data
+    restart: unless-stopped
+
+volumes:
+  liftlog_data:
+```
+
+### Building Docker Image
+
+```bash
+docker build -t liftlog:latest .
+```
+
+## Development
+
+### Prerequisites
+
+- Rust (stable)
+- SQLite (bundled via rusqlite)
+
+### Running Locally
+
+```bash
+cargo run
+```
+
+### Running Tests
+
+```bash
+cargo test
+```
+
+### Code Quality
+
+```bash
+cargo fmt --check
+cargo clippy -- -D warnings
+```
+
+## Tech Stack
+
+- **Web Framework**: Axum 0.7
+- **Async Runtime**: Tokio
+- **Database**: SQLite (rusqlite + r2d2)
+- **Templates**: Askama
+- **Password Hashing**: Argon2
+
+## License
+
+MIT

--- a/src/db.rs
+++ b/src/db.rs
@@ -3,6 +3,7 @@ use r2d2_sqlite::SqliteConnectionManager;
 use std::path::Path;
 
 pub type DbPool = Pool<SqliteConnectionManager>;
+#[allow(dead_code)]
 pub type DbConnection = PooledConnection<SqliteConnectionManager>;
 
 pub fn create_pool(database_url: &str) -> Result<DbPool, r2d2::Error> {
@@ -16,14 +17,11 @@ pub fn create_pool(database_url: &str) -> Result<DbPool, r2d2::Error> {
         SqliteConnectionManager::file(Path::new(path))
     };
 
-    Pool::builder()
-        .max_size(5)
-        .build(manager)
+    Pool::builder().max_size(5).build(manager)
 }
 
+#[allow(dead_code)]
 pub fn create_memory_pool() -> Result<DbPool, r2d2::Error> {
     let manager = SqliteConnectionManager::memory();
-    Pool::builder()
-        .max_size(1)
-        .build(manager)
+    Pool::builder().max_size(1).build(manager)
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,0 +1,27 @@
+use r2d2::{Pool, PooledConnection};
+use r2d2_sqlite::SqliteConnectionManager;
+use std::path::Path;
+
+pub type DbPool = Pool<SqliteConnectionManager>;
+pub type DbConnection = PooledConnection<SqliteConnectionManager>;
+
+pub fn create_pool(database_url: &str) -> Result<DbPool, r2d2::Error> {
+    let path = database_url.strip_prefix("sqlite:").unwrap_or(database_url);
+
+    let manager = if path == ":memory:" {
+        SqliteConnectionManager::memory()
+    } else {
+        SqliteConnectionManager::file(Path::new(path))
+    };
+
+    Pool::builder()
+        .max_size(5)
+        .build(manager)
+}
+
+pub fn create_memory_pool() -> Result<DbPool, r2d2::Error> {
+    let manager = SqliteConnectionManager::memory();
+    Pool::builder()
+        .max_size(1)
+        .build(manager)
+}

--- a/src/db.rs
+++ b/src/db.rs
@@ -7,6 +7,8 @@ pub type DbConnection = PooledConnection<SqliteConnectionManager>;
 
 pub fn create_pool(database_url: &str) -> Result<DbPool, r2d2::Error> {
     let path = database_url.strip_prefix("sqlite:").unwrap_or(database_url);
+    // Remove query parameters (e.g., ?mode=rwc)
+    let path = path.split('?').next().unwrap_or(path);
 
     let manager = if path == ":memory:" {
         SqliteConnectionManager::memory()

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,12 +16,15 @@ pub enum AppError {
     NotFound(String),
 
     #[error("Unauthorized")]
+    #[allow(dead_code)]
     Unauthorized,
 
     #[error("Bad request: {0}")]
+    #[allow(dead_code)]
     BadRequest(String),
 
     #[error("Validation error: {0}")]
+    #[allow(dead_code)]
     Validation(String),
 
     #[error("Internal error: {0}")]
@@ -36,11 +39,17 @@ impl IntoResponse for AppError {
         let (status, message) = match &self {
             AppError::Database(e) => {
                 tracing::error!("Database error: {:?}", e);
-                (StatusCode::INTERNAL_SERVER_ERROR, "Database error".to_string())
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Database error".to_string(),
+                )
             }
             AppError::Pool(e) => {
                 tracing::error!("Pool error: {:?}", e);
-                (StatusCode::INTERNAL_SERVER_ERROR, "Database error".to_string())
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Database error".to_string(),
+                )
             }
             AppError::NotFound(msg) => (StatusCode::NOT_FOUND, msg.clone()),
             AppError::Unauthorized => (StatusCode::UNAUTHORIZED, "Unauthorized".to_string()),
@@ -48,11 +57,17 @@ impl IntoResponse for AppError {
             AppError::Validation(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
             AppError::Internal(msg) => {
                 tracing::error!("Internal error: {}", msg);
-                (StatusCode::INTERNAL_SERVER_ERROR, "Internal error".to_string())
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Internal error".to_string(),
+                )
             }
             AppError::PasswordHash => {
                 tracing::error!("Password hash error");
-                (StatusCode::INTERNAL_SERVER_ERROR, "Internal error".to_string())
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Internal error".to_string(),
+                )
             }
         };
 

--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -1,15 +1,17 @@
 use askama::Template;
 use axum::{
     extract::State,
+    http::HeaderMap,
     response::{Html, IntoResponse, Redirect, Response},
-    Form,
+    Extension, Form,
 };
-use tower_sessions::Session;
+use axum_extra::extract::cookie::SignedCookieJar;
 
 use crate::error::{AppError, Result};
 use crate::middleware::{AuthUser, auth::OptionalAuthUser};
 use crate::models::{CreateUser, LoginCredentials, User};
 use crate::repositories::UserRepository;
+use crate::session::SessionKey;
 
 #[derive(Clone)]
 pub struct AuthState {
@@ -65,9 +67,12 @@ pub async fn login_page(
 
 pub async fn login_submit(
     State(state): State<AuthState>,
-    session: Session,
+    Extension(key): Extension<SessionKey>,
+    headers: HeaderMap,
     Form(credentials): Form<LoginCredentials>,
 ) -> Result<Response> {
+    let jar = SignedCookieJar::from_headers(&headers, key.0);
+
     let user = state
         .user_repo
         .verify_password(&credentials.username, &credentials.password)
@@ -75,16 +80,14 @@ pub async fn login_submit(
 
     match user {
         Some(user) => {
-            AuthUser::login(&session, &user)
-                .await
-                .map_err(|e| AppError::Internal(e.to_string()))?;
-            Ok(Redirect::to("/").into_response())
+            let jar = AuthUser::login(jar, &user);
+            Ok((jar, Redirect::to("/")).into_response())
         }
         None => {
             let template = LoginTemplate {
                 error: Some("Invalid username or password".to_string()),
             };
-            Ok(Html(template.render().map_err(|e| AppError::Internal(e.to_string()))?).into_response())
+            Ok((jar, Html(template.render().map_err(|e| AppError::Internal(e.to_string()))?)).into_response())
         }
     }
 }
@@ -104,13 +107,16 @@ pub async fn setup_page(
 
 pub async fn setup_submit(
     State(state): State<AuthState>,
-    session: Session,
+    Extension(key): Extension<SessionKey>,
+    headers: HeaderMap,
     Form(form): Form<CreateUser>,
 ) -> Result<Response> {
+    let jar = SignedCookieJar::from_headers(&headers, key.0);
+
     // Only allow setup if no users exist
     let user_count = state.user_repo.count().await?;
     if user_count > 0 {
-        return Ok(Redirect::to("/auth/login").into_response());
+        return Ok((jar, Redirect::to("/auth/login")).into_response());
     }
 
     // Validate input
@@ -118,32 +124,32 @@ pub async fn setup_submit(
         let template = SetupTemplate {
             error: Some("Username is required".to_string()),
         };
-        return Ok(Html(template.render().map_err(|e| AppError::Internal(e.to_string()))?).into_response());
+        return Ok((jar, Html(template.render().map_err(|e| AppError::Internal(e.to_string()))?)).into_response());
     }
 
     if form.password.len() < 6 {
         let template = SetupTemplate {
             error: Some("Password must be at least 6 characters".to_string()),
         };
-        return Ok(Html(template.render().map_err(|e| AppError::Internal(e.to_string()))?).into_response());
+        return Ok((jar, Html(template.render().map_err(|e| AppError::Internal(e.to_string()))?)).into_response());
     }
 
     // Create the first user (admin)
     let user = state.user_repo.create(&form.username, &form.password).await?;
 
     // Auto login
-    AuthUser::login(&session, &user)
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?;
+    let jar = AuthUser::login(jar, &user);
 
-    Ok(Redirect::to("/").into_response())
+    Ok((jar, Redirect::to("/")).into_response())
 }
 
-pub async fn logout(session: Session) -> Result<Response> {
-    AuthUser::logout(&session)
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?;
-    Ok(Redirect::to("/auth/login").into_response())
+pub async fn logout(
+    Extension(key): Extension<SessionKey>,
+    headers: HeaderMap,
+) -> Response {
+    let jar = SignedCookieJar::from_headers(&headers, key.0);
+    let jar = AuthUser::logout(jar);
+    (jar, Redirect::to("/auth/login")).into_response()
 }
 
 pub async fn new_user_page(auth_user: AuthUser) -> Result<Response> {

--- a/src/handlers/dashboard.rs
+++ b/src/handlers/dashboard.rs
@@ -24,13 +24,19 @@ struct DashboardTemplate {
     recent_workouts: Vec<WorkoutSession>,
 }
 
-pub async fn index(
-    State(state): State<DashboardState>,
-    auth_user: AuthUser,
-) -> Result<Response> {
-    let workouts_this_week = state.workout_repo.count_workouts_this_week(&auth_user.id).await?;
-    let workouts_this_month = state.workout_repo.count_workouts_this_month(&auth_user.id).await?;
-    let total_volume = state.workout_repo.get_total_volume_this_week(&auth_user.id).await?;
+pub async fn index(State(state): State<DashboardState>, auth_user: AuthUser) -> Result<Response> {
+    let workouts_this_week = state
+        .workout_repo
+        .count_workouts_this_week(&auth_user.id)
+        .await?;
+    let workouts_this_month = state
+        .workout_repo
+        .count_workouts_this_month(&auth_user.id)
+        .await?;
+    let total_volume = state
+        .workout_repo
+        .get_total_volume_this_week(&auth_user.id)
+        .await?;
     let recent_workouts = state
         .workout_repo
         .find_sessions_by_user_paginated(&auth_user.id, 5, 0)
@@ -44,5 +50,10 @@ pub async fn index(
         recent_workouts,
     };
 
-    Ok(Html(template.render().map_err(|e| AppError::Internal(e.to_string()))?).into_response())
+    Ok(Html(
+        template
+            .render()
+            .map_err(|e| AppError::Internal(e.to_string()))?,
+    )
+    .into_response())
 }

--- a/src/handlers/exercises.rs
+++ b/src/handlers/exercises.rs
@@ -31,11 +31,11 @@ struct NewExerciseTemplate {
     error: Option<String>,
 }
 
-pub async fn list(
-    State(state): State<ExercisesState>,
-    auth_user: AuthUser,
-) -> Result<Response> {
-    let exercises = state.exercise_repo.find_available_for_user(&auth_user.id).await?;
+pub async fn list(State(state): State<ExercisesState>, auth_user: AuthUser) -> Result<Response> {
+    let exercises = state
+        .exercise_repo
+        .find_available_for_user(&auth_user.id)
+        .await?;
 
     let template = ExercisesListTemplate {
         user: auth_user,
@@ -43,7 +43,12 @@ pub async fn list(
         categories: CATEGORIES,
     };
 
-    Ok(Html(template.render().map_err(|e| AppError::Internal(e.to_string()))?).into_response())
+    Ok(Html(
+        template
+            .render()
+            .map_err(|e| AppError::Internal(e.to_string()))?,
+    )
+    .into_response())
 }
 
 pub async fn new_page(auth_user: AuthUser) -> Result<Response> {
@@ -53,7 +58,12 @@ pub async fn new_page(auth_user: AuthUser) -> Result<Response> {
         error: None,
     };
 
-    Ok(Html(template.render().map_err(|e| AppError::Internal(e.to_string()))?).into_response())
+    Ok(Html(
+        template
+            .render()
+            .map_err(|e| AppError::Internal(e.to_string()))?,
+    )
+    .into_response())
 }
 
 pub async fn create(
@@ -67,7 +77,12 @@ pub async fn create(
             categories: CATEGORIES,
             error: Some("Exercise name is required".to_string()),
         };
-        return Ok(Html(template.render().map_err(|e| AppError::Internal(e.to_string()))?).into_response());
+        return Ok(Html(
+            template
+                .render()
+                .map_err(|e| AppError::Internal(e.to_string()))?,
+        )
+        .into_response());
     }
 
     state

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,5 +1,5 @@
 pub mod auth;
 pub mod dashboard;
-pub mod workouts;
 pub mod exercises;
 pub mod stats;
+pub mod workouts;

--- a/src/handlers/stats.rs
+++ b/src/handlers/stats.rs
@@ -42,14 +42,23 @@ struct PrsTemplate {
     prs: Vec<PersonalRecordWithExercise>,
 }
 
-pub async fn index(
-    State(state): State<StatsState>,
-    auth_user: AuthUser,
-) -> Result<Response> {
-    let workouts_this_week = state.workout_repo.count_workouts_this_week(&auth_user.id).await?;
-    let workouts_this_month = state.workout_repo.count_workouts_this_month(&auth_user.id).await?;
-    let total_volume = state.workout_repo.get_total_volume_this_week(&auth_user.id).await?;
-    let total_workouts = state.workout_repo.count_sessions_by_user(&auth_user.id).await?;
+pub async fn index(State(state): State<StatsState>, auth_user: AuthUser) -> Result<Response> {
+    let workouts_this_week = state
+        .workout_repo
+        .count_workouts_this_week(&auth_user.id)
+        .await?;
+    let workouts_this_month = state
+        .workout_repo
+        .count_workouts_this_month(&auth_user.id)
+        .await?;
+    let total_volume = state
+        .workout_repo
+        .get_total_volume_this_week(&auth_user.id)
+        .await?;
+    let total_workouts = state
+        .workout_repo
+        .count_sessions_by_user(&auth_user.id)
+        .await?;
     let prs = state.workout_repo.find_prs_by_user(&auth_user.id).await?;
 
     let template = StatsTemplate {
@@ -61,7 +70,12 @@ pub async fn index(
         prs,
     };
 
-    Ok(Html(template.render().map_err(|e| AppError::Internal(e.to_string()))?).into_response())
+    Ok(Html(
+        template
+            .render()
+            .map_err(|e| AppError::Internal(e.to_string()))?,
+    )
+    .into_response())
 }
 
 pub async fn exercise_stats(
@@ -92,16 +106,26 @@ pub async fn exercise_stats(
         prs,
     };
 
-    Ok(Html(template.render().map_err(|e| AppError::Internal(e.to_string()))?).into_response())
+    Ok(Html(
+        template
+            .render()
+            .map_err(|e| AppError::Internal(e.to_string()))?,
+    )
+    .into_response())
 }
 
-pub async fn prs_list(
-    State(state): State<StatsState>,
-    auth_user: AuthUser,
-) -> Result<Response> {
+pub async fn prs_list(State(state): State<StatsState>, auth_user: AuthUser) -> Result<Response> {
     let prs = state.workout_repo.find_prs_by_user(&auth_user.id).await?;
 
-    let template = PrsTemplate { user: auth_user, prs };
+    let template = PrsTemplate {
+        user: auth_user,
+        prs,
+    };
 
-    Ok(Html(template.render().map_err(|e| AppError::Internal(e.to_string()))?).into_response())
+    Ok(Html(
+        template
+            .render()
+            .map_err(|e| AppError::Internal(e.to_string()))?,
+    )
+    .into_response())
 }

--- a/src/handlers/workouts.rs
+++ b/src/handlers/workouts.rs
@@ -9,7 +9,9 @@ use serde::Deserialize;
 
 use crate::error::{AppError, Result};
 use crate::middleware::AuthUser;
-use crate::models::{CreateWorkoutLog, CreateWorkoutSession, Exercise, WorkoutLogWithExercise, WorkoutSession};
+use crate::models::{
+    CreateWorkoutLog, CreateWorkoutSession, Exercise, WorkoutLogWithExercise, WorkoutSession,
+};
 use crate::repositories::{ExerciseRepository, WorkoutRepository};
 
 #[derive(Clone)]
@@ -75,7 +77,10 @@ pub async fn list(
         .find_sessions_by_user_paginated(&auth_user.id, per_page, offset)
         .await?;
 
-    let total = state.workout_repo.count_sessions_by_user(&auth_user.id).await?;
+    let total = state
+        .workout_repo
+        .count_sessions_by_user(&auth_user.id)
+        .await?;
     let total_pages = (total + per_page - 1) / per_page;
 
     let template = WorkoutsListTemplate {
@@ -85,7 +90,12 @@ pub async fn list(
         total_pages,
     };
 
-    Ok(Html(template.render().map_err(|e| AppError::Internal(e.to_string()))?).into_response())
+    Ok(Html(
+        template
+            .render()
+            .map_err(|e| AppError::Internal(e.to_string()))?,
+    )
+    .into_response())
 }
 
 pub async fn new_page(auth_user: AuthUser) -> Result<Response> {
@@ -97,7 +107,12 @@ pub async fn new_page(auth_user: AuthUser) -> Result<Response> {
         error: None,
     };
 
-    Ok(Html(template.render().map_err(|e| AppError::Internal(e.to_string()))?).into_response())
+    Ok(Html(
+        template
+            .render()
+            .map_err(|e| AppError::Internal(e.to_string()))?,
+    )
+    .into_response())
 }
 
 pub async fn create(
@@ -130,7 +145,10 @@ pub async fn show(
     }
 
     let logs = state.workout_repo.find_logs_by_session(&id).await?;
-    let exercises = state.exercise_repo.find_available_for_user(&auth_user.id).await?;
+    let exercises = state
+        .exercise_repo
+        .find_available_for_user(&auth_user.id)
+        .await?;
 
     let template = ShowWorkoutTemplate {
         user: auth_user,
@@ -140,7 +158,12 @@ pub async fn show(
         error: None,
     };
 
-    Ok(Html(template.render().map_err(|e| AppError::Internal(e.to_string()))?).into_response())
+    Ok(Html(
+        template
+            .render()
+            .map_err(|e| AppError::Internal(e.to_string()))?,
+    )
+    .into_response())
 }
 
 pub async fn edit_page(
@@ -164,7 +187,12 @@ pub async fn edit_page(
         error: None,
     };
 
-    Ok(Html(template.render().map_err(|e| AppError::Internal(e.to_string()))?).into_response())
+    Ok(Html(
+        template
+            .render()
+            .map_err(|e| AppError::Internal(e.to_string()))?,
+    )
+    .into_response())
 }
 
 #[derive(Deserialize)]
@@ -192,7 +220,10 @@ pub async fn delete(
     auth_user: AuthUser,
     Path(id): Path<String>,
 ) -> Result<Response> {
-    state.workout_repo.delete_session(&id, &auth_user.id).await?;
+    state
+        .workout_repo
+        .delete_session(&id, &auth_user.id)
+        .await?;
     Ok(Redirect::to("/workouts").into_response())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod config;
+pub mod db;
 pub mod error;
 pub mod handlers;
 pub mod middleware;
 pub mod models;
 pub mod repositories;
 pub mod routes;
+pub mod session;

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,12 @@ fn run_migrations(pool: &DbPool) -> anyhow::Result<()> {
     let migrations_dir = PathBuf::from("migrations");
     let mut entries: Vec<_> = std::fs::read_dir(&migrations_dir)?
         .filter_map(|e| e.ok())
-        .filter(|e| e.path().extension().map(|ext| ext == "sql").unwrap_or(false))
+        .filter(|e| {
+            e.path()
+                .extension()
+                .map(|ext| ext == "sql")
+                .unwrap_or(false)
+        })
         .collect();
 
     entries.sort_by_key(|e| e.file_name());

--- a/src/middleware/auth.rs
+++ b/src/middleware/auth.rs
@@ -3,13 +3,14 @@ use axum::{
     extract::FromRequestParts,
     http::{request::Parts, StatusCode},
     response::{IntoResponse, Redirect, Response},
+    Extension,
 };
-use tower_sessions::Session;
+use axum_extra::extract::cookie::SignedCookieJar;
 
 use crate::models::User;
-
-const USER_ID_KEY: &str = "user_id";
-const USERNAME_KEY: &str = "username";
+use crate::session::{
+    create_session_cookie, get_session_from_jar, remove_session_cookie, SessionData, SessionKey,
+};
 
 #[derive(Clone, Debug)]
 pub struct AuthUser {
@@ -18,20 +19,20 @@ pub struct AuthUser {
 }
 
 impl AuthUser {
-    pub async fn login(session: &Session, user: &User) -> Result<(), tower_sessions::session::Error> {
-        session.insert(USER_ID_KEY, &user.id).await?;
-        session.insert(USERNAME_KEY, &user.username).await?;
-        Ok(())
+    pub fn login(jar: SignedCookieJar, user: &User) -> SignedCookieJar {
+        let data = SessionData::new(user.id.clone(), user.username.clone());
+        jar.add(create_session_cookie(&data))
     }
 
-    pub async fn logout(session: &Session) -> Result<(), tower_sessions::session::Error> {
-        session.flush().await
+    pub fn logout(jar: SignedCookieJar) -> SignedCookieJar {
+        jar.remove(remove_session_cookie())
     }
 
-    pub async fn from_session(session: &Session) -> Option<Self> {
-        let id = session.get::<String>(USER_ID_KEY).await.ok()??;
-        let username = session.get::<String>(USERNAME_KEY).await.ok()??;
-        Some(Self { id, username })
+    pub fn from_jar(jar: &SignedCookieJar) -> Option<Self> {
+        get_session_from_jar(jar).map(|data| Self {
+            id: data.user_id,
+            username: data.username,
+        })
     }
 }
 
@@ -43,11 +44,13 @@ where
     type Rejection = AuthRedirect;
 
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-        let session = Session::from_request_parts(parts, state)
+        let Extension(key) = Extension::<SessionKey>::from_request_parts(parts, state)
             .await
             .map_err(|_| AuthRedirect)?;
 
-        AuthUser::from_session(&session).await.ok_or(AuthRedirect)
+        let jar = SignedCookieJar::from_headers(&parts.headers, key.0);
+
+        AuthUser::from_jar(&jar).ok_or(AuthRedirect)
     }
 }
 
@@ -70,10 +73,12 @@ where
     type Rejection = (StatusCode, &'static str);
 
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-        let session = Session::from_request_parts(parts, state)
+        let Extension(key) = Extension::<SessionKey>::from_request_parts(parts, state)
             .await
             .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Session error"))?;
 
-        Ok(OptionalAuthUser(AuthUser::from_session(&session).await))
+        let jar = SignedCookieJar::from_headers(&parts.headers, key.0);
+
+        Ok(OptionalAuthUser(AuthUser::from_jar(&jar)))
     }
 }

--- a/src/models/exercise.rs
+++ b/src/models/exercise.rs
@@ -1,7 +1,9 @@
+use rusqlite::Row;
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+use super::FromSqliteRow;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Exercise {
     pub id: String,
     pub name: String,
@@ -10,6 +12,20 @@ pub struct Exercise {
     pub equipment: Option<String>,
     pub is_default: bool,
     pub user_id: Option<String>,
+}
+
+impl FromSqliteRow for Exercise {
+    fn from_row(row: &Row) -> rusqlite::Result<Self> {
+        Ok(Self {
+            id: row.get("id")?,
+            name: row.get("name")?,
+            category: row.get("category")?,
+            muscle_group: row.get("muscle_group")?,
+            equipment: row.get("equipment")?,
+            is_default: row.get("is_default")?,
+            user_id: row.get("user_id")?,
+        })
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/models/exercise.rs
+++ b/src/models/exercise.rs
@@ -43,10 +43,28 @@ pub struct ExerciseCategory {
 }
 
 pub const CATEGORIES: &[ExerciseCategory] = &[
-    ExerciseCategory { name: "chest", display_name: "胸" },
-    ExerciseCategory { name: "back", display_name: "背" },
-    ExerciseCategory { name: "legs", display_name: "腿" },
-    ExerciseCategory { name: "shoulders", display_name: "肩" },
-    ExerciseCategory { name: "arms", display_name: "手臂" },
-    ExerciseCategory { name: "core", display_name: "核心" },
+    ExerciseCategory {
+        name: "chest",
+        display_name: "胸",
+    },
+    ExerciseCategory {
+        name: "back",
+        display_name: "背",
+    },
+    ExerciseCategory {
+        name: "legs",
+        display_name: "腿",
+    },
+    ExerciseCategory {
+        name: "shoulders",
+        display_name: "肩",
+    },
+    ExerciseCategory {
+        name: "arms",
+        display_name: "手臂",
+    },
+    ExerciseCategory {
+        name: "core",
+        display_name: "核心",
+    },
 ];

--- a/src/models/from_row.rs
+++ b/src/models/from_row.rs
@@ -1,0 +1,5 @@
+use rusqlite::Row;
+
+pub trait FromSqliteRow: Sized {
+    fn from_row(row: &Row) -> rusqlite::Result<Self>;
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,9 +1,11 @@
+pub mod from_row;
 pub mod user;
 pub mod exercise;
 pub mod workout_session;
 pub mod workout_log;
 pub mod personal_record;
 
+pub use from_row::FromSqliteRow;
 pub use user::{User, CreateUser, LoginCredentials};
 pub use exercise::{Exercise, CreateExercise};
 pub use workout_session::{WorkoutSession, CreateWorkoutSession};

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,13 +1,13 @@
-pub mod from_row;
-pub mod user;
 pub mod exercise;
-pub mod workout_session;
-pub mod workout_log;
+pub mod from_row;
 pub mod personal_record;
+pub mod user;
+pub mod workout_log;
+pub mod workout_session;
 
+pub use exercise::{CreateExercise, Exercise};
 pub use from_row::FromSqliteRow;
-pub use user::{User, CreateUser, LoginCredentials};
-pub use exercise::{Exercise, CreateExercise};
-pub use workout_session::{WorkoutSession, CreateWorkoutSession};
-pub use workout_log::{WorkoutLog, WorkoutLogWithExercise, CreateWorkoutLog};
 pub use personal_record::{PersonalRecord, PersonalRecordWithExercise};
+pub use user::{CreateUser, LoginCredentials, User};
+pub use workout_log::{CreateWorkoutLog, WorkoutLog, WorkoutLogWithExercise};
+pub use workout_session::{CreateWorkoutSession, WorkoutSession};

--- a/src/models/personal_record.rs
+++ b/src/models/personal_record.rs
@@ -1,8 +1,10 @@
 use chrono::{DateTime, Utc};
+use rusqlite::Row;
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+use super::FromSqliteRow;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PersonalRecord {
     pub id: String,
     pub user_id: String,
@@ -12,7 +14,20 @@ pub struct PersonalRecord {
     pub achieved_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, Serialize, FromRow)]
+impl FromSqliteRow for PersonalRecord {
+    fn from_row(row: &Row) -> rusqlite::Result<Self> {
+        Ok(Self {
+            id: row.get("id")?,
+            user_id: row.get("user_id")?,
+            exercise_id: row.get("exercise_id")?,
+            record_type: row.get("record_type")?,
+            value: row.get("value")?,
+            achieved_at: row.get("achieved_at")?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct PersonalRecordWithExercise {
     pub id: String,
     pub user_id: String,
@@ -21,6 +36,20 @@ pub struct PersonalRecordWithExercise {
     pub record_type: String,
     pub value: f64,
     pub achieved_at: DateTime<Utc>,
+}
+
+impl FromSqliteRow for PersonalRecordWithExercise {
+    fn from_row(row: &Row) -> rusqlite::Result<Self> {
+        Ok(Self {
+            id: row.get("id")?,
+            user_id: row.get("user_id")?,
+            exercise_id: row.get("exercise_id")?,
+            exercise_name: row.get("exercise_name")?,
+            record_type: row.get("record_type")?,
+            value: row.get("value")?,
+            achieved_at: row.get("achieved_at")?,
+        })
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/models/personal_record.rs
+++ b/src/models/personal_record.rs
@@ -52,6 +52,7 @@ impl FromSqliteRow for PersonalRecordWithExercise {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RecordType {
     MaxWeight,
@@ -59,6 +60,7 @@ pub enum RecordType {
     FiveRepMax,
 }
 
+#[allow(dead_code)]
 impl RecordType {
     pub fn as_str(&self) -> &'static str {
         match self {

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -1,13 +1,26 @@
 use chrono::{DateTime, Utc};
+use rusqlite::Row;
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+use super::FromSqliteRow;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct User {
     pub id: String,
     pub username: String,
     pub password_hash: String,
     pub created_at: DateTime<Utc>,
+}
+
+impl FromSqliteRow for User {
+    fn from_row(row: &Row) -> rusqlite::Result<Self> {
+        Ok(Self {
+            id: row.get("id")?,
+            username: row.get("username")?,
+            password_hash: row.get("password_hash")?,
+            created_at: row.get("created_at")?,
+        })
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/models/workout_log.rs
+++ b/src/models/workout_log.rs
@@ -36,8 +36,6 @@ impl FromSqliteRow for WorkoutLog {
 #[derive(Debug, Deserialize)]
 pub struct CreateWorkoutLog {
     pub exercise_id: String,
-    #[allow(dead_code)]
-    pub set_number: i32,
     pub reps: i32,
     pub weight: f64,
     pub rpe: Option<i32>,

--- a/src/models/workout_log.rs
+++ b/src/models/workout_log.rs
@@ -36,6 +36,7 @@ impl FromSqliteRow for WorkoutLog {
 #[derive(Debug, Deserialize)]
 pub struct CreateWorkoutLog {
     pub exercise_id: String,
+    #[allow(dead_code)]
     pub set_number: i32,
     pub reps: i32,
     pub weight: f64,

--- a/src/models/workout_log.rs
+++ b/src/models/workout_log.rs
@@ -1,8 +1,10 @@
 use chrono::{DateTime, Utc};
+use rusqlite::Row;
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+use super::FromSqliteRow;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkoutLog {
     pub id: String,
     pub session_id: String,
@@ -15,6 +17,22 @@ pub struct WorkoutLog {
     pub created_at: DateTime<Utc>,
 }
 
+impl FromSqliteRow for WorkoutLog {
+    fn from_row(row: &Row) -> rusqlite::Result<Self> {
+        Ok(Self {
+            id: row.get("id")?,
+            session_id: row.get("session_id")?,
+            exercise_id: row.get("exercise_id")?,
+            set_number: row.get("set_number")?,
+            reps: row.get("reps")?,
+            weight: row.get("weight")?,
+            rpe: row.get("rpe")?,
+            is_pr: row.get("is_pr")?,
+            created_at: row.get("created_at")?,
+        })
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct CreateWorkoutLog {
     pub exercise_id: String,
@@ -24,7 +42,7 @@ pub struct CreateWorkoutLog {
     pub rpe: Option<i32>,
 }
 
-#[derive(Debug, Clone, Serialize, FromRow)]
+#[derive(Debug, Clone, Serialize)]
 pub struct WorkoutLogWithExercise {
     pub id: String,
     pub session_id: String,
@@ -35,4 +53,20 @@ pub struct WorkoutLogWithExercise {
     pub weight: f64,
     pub rpe: Option<i32>,
     pub is_pr: bool,
+}
+
+impl FromSqliteRow for WorkoutLogWithExercise {
+    fn from_row(row: &Row) -> rusqlite::Result<Self> {
+        Ok(Self {
+            id: row.get("id")?,
+            session_id: row.get("session_id")?,
+            exercise_id: row.get("exercise_id")?,
+            exercise_name: row.get("exercise_name")?,
+            set_number: row.get("set_number")?,
+            reps: row.get("reps")?,
+            weight: row.get("weight")?,
+            rpe: row.get("rpe")?,
+            is_pr: row.get("is_pr")?,
+        })
+    }
 }

--- a/src/models/workout_session.rs
+++ b/src/models/workout_session.rs
@@ -31,6 +31,7 @@ pub struct CreateWorkoutSession {
     pub notes: Option<String>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub struct UpdateWorkoutSession {
     pub date: Option<NaiveDate>,

--- a/src/models/workout_session.rs
+++ b/src/models/workout_session.rs
@@ -1,14 +1,28 @@
 use chrono::{DateTime, NaiveDate, Utc};
+use rusqlite::Row;
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+use super::FromSqliteRow;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkoutSession {
     pub id: String,
     pub user_id: String,
     pub date: NaiveDate,
     pub notes: Option<String>,
     pub created_at: DateTime<Utc>,
+}
+
+impl FromSqliteRow for WorkoutSession {
+    fn from_row(row: &Row) -> rusqlite::Result<Self> {
+        Ok(Self {
+            id: row.get("id")?,
+            user_id: row.get("user_id")?,
+            date: row.get("date")?,
+            notes: row.get("notes")?,
+            created_at: row.get("created_at")?,
+        })
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/repositories/exercise_repo.rs
+++ b/src/repositories/exercise_repo.rs
@@ -21,22 +21,21 @@ impl ExerciseRepository {
         tokio::task::spawn_blocking(move || {
             let conn = pool.get()?;
             let mut stmt = conn.prepare("SELECT * FROM exercises WHERE id = ?")?;
-            let result = stmt
-                .query_row([&id], |row| Exercise::from_row(row))
-                .optional()?;
+            let result = stmt.query_row([&id], Exercise::from_row).optional()?;
             Ok(result)
         })
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
+    #[allow(dead_code)]
     pub async fn find_all(&self) -> Result<Vec<Exercise>> {
         let pool = self.pool.clone();
         tokio::task::spawn_blocking(move || {
             let conn = pool.get()?;
             let mut stmt = conn.prepare("SELECT * FROM exercises ORDER BY category, name")?;
             let exercises = stmt
-                .query_map([], |row| Exercise::from_row(row))?
+                .query_map([], Exercise::from_row)?
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             Ok(exercises)
         })
@@ -44,14 +43,16 @@ impl ExerciseRepository {
         .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
+    #[allow(dead_code)]
     pub async fn find_by_category(&self, category: &str) -> Result<Vec<Exercise>> {
         let pool = self.pool.clone();
         let category = category.to_string();
         tokio::task::spawn_blocking(move || {
             let conn = pool.get()?;
-            let mut stmt = conn.prepare("SELECT * FROM exercises WHERE category = ? ORDER BY name")?;
+            let mut stmt =
+                conn.prepare("SELECT * FROM exercises WHERE category = ? ORDER BY name")?;
             let exercises = stmt
-                .query_map([&category], |row| Exercise::from_row(row))?
+                .query_map([&category], Exercise::from_row)?
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             Ok(exercises)
         })
@@ -68,7 +69,7 @@ impl ExerciseRepository {
                 "SELECT * FROM exercises WHERE is_default = 1 OR user_id = ? ORDER BY category, name"
             )?;
             let exercises = stmt
-                .query_map([&user_id], |row| Exercise::from_row(row))?
+                .query_map([&user_id], Exercise::from_row)?
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             Ok(exercises)
         })
@@ -76,16 +77,16 @@ impl ExerciseRepository {
         .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
+    #[allow(dead_code)]
     pub async fn find_user_custom(&self, user_id: &str) -> Result<Vec<Exercise>> {
         let pool = self.pool.clone();
         let user_id = user_id.to_string();
         tokio::task::spawn_blocking(move || {
             let conn = pool.get()?;
-            let mut stmt = conn.prepare(
-                "SELECT * FROM exercises WHERE user_id = ? ORDER BY category, name"
-            )?;
+            let mut stmt =
+                conn.prepare("SELECT * FROM exercises WHERE user_id = ? ORDER BY category, name")?;
             let exercises = stmt
-                .query_map([&user_id], |row| Exercise::from_row(row))?
+                .query_map([&user_id], Exercise::from_row)?
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             Ok(exercises)
         })
@@ -136,6 +137,7 @@ impl ExerciseRepository {
         Ok(exercise)
     }
 
+    #[allow(dead_code)]
     pub async fn delete(&self, id: &str, user_id: &str) -> Result<bool> {
         let pool = self.pool.clone();
         let id = id.to_string();

--- a/src/repositories/exercise_repo.rs
+++ b/src/repositories/exercise_repo.rs
@@ -1,64 +1,96 @@
-use sqlx::SqlitePool;
+use rusqlite::OptionalExtension;
 use uuid::Uuid;
 
-use crate::error::Result;
-use crate::models::Exercise;
+use crate::db::DbPool;
+use crate::error::{AppError, Result};
+use crate::models::{Exercise, FromSqliteRow};
 
 #[derive(Clone)]
 pub struct ExerciseRepository {
-    pool: SqlitePool,
+    pool: DbPool,
 }
 
 impl ExerciseRepository {
-    pub fn new(pool: SqlitePool) -> Self {
+    pub fn new(pool: DbPool) -> Self {
         Self { pool }
     }
 
     pub async fn find_by_id(&self, id: &str) -> Result<Option<Exercise>> {
-        let exercise = sqlx::query_as::<_, Exercise>("SELECT * FROM exercises WHERE id = ?")
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await?;
-        Ok(exercise)
+        let pool = self.pool.clone();
+        let id = id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let mut stmt = conn.prepare("SELECT * FROM exercises WHERE id = ?")?;
+            let result = stmt
+                .query_row([&id], |row| Exercise::from_row(row))
+                .optional()?;
+            Ok(result)
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
     pub async fn find_all(&self) -> Result<Vec<Exercise>> {
-        let exercises = sqlx::query_as::<_, Exercise>(
-            "SELECT * FROM exercises ORDER BY category, name"
-        )
-        .fetch_all(&self.pool)
-        .await?;
-        Ok(exercises)
+        let pool = self.pool.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let mut stmt = conn.prepare("SELECT * FROM exercises ORDER BY category, name")?;
+            let exercises = stmt
+                .query_map([], |row| Exercise::from_row(row))?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            Ok(exercises)
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
     pub async fn find_by_category(&self, category: &str) -> Result<Vec<Exercise>> {
-        let exercises = sqlx::query_as::<_, Exercise>(
-            "SELECT * FROM exercises WHERE category = ? ORDER BY name"
-        )
-        .bind(category)
-        .fetch_all(&self.pool)
-        .await?;
-        Ok(exercises)
+        let pool = self.pool.clone();
+        let category = category.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let mut stmt = conn.prepare("SELECT * FROM exercises WHERE category = ? ORDER BY name")?;
+            let exercises = stmt
+                .query_map([&category], |row| Exercise::from_row(row))?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            Ok(exercises)
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
     pub async fn find_available_for_user(&self, user_id: &str) -> Result<Vec<Exercise>> {
-        let exercises = sqlx::query_as::<_, Exercise>(
-            "SELECT * FROM exercises WHERE is_default = 1 OR user_id = ? ORDER BY category, name"
-        )
-        .bind(user_id)
-        .fetch_all(&self.pool)
-        .await?;
-        Ok(exercises)
+        let pool = self.pool.clone();
+        let user_id = user_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let mut stmt = conn.prepare(
+                "SELECT * FROM exercises WHERE is_default = 1 OR user_id = ? ORDER BY category, name"
+            )?;
+            let exercises = stmt
+                .query_map([&user_id], |row| Exercise::from_row(row))?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            Ok(exercises)
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
     pub async fn find_user_custom(&self, user_id: &str) -> Result<Vec<Exercise>> {
-        let exercises = sqlx::query_as::<_, Exercise>(
-            "SELECT * FROM exercises WHERE user_id = ? ORDER BY category, name"
-        )
-        .bind(user_id)
-        .fetch_all(&self.pool)
-        .await?;
-        Ok(exercises)
+        let pool = self.pool.clone();
+        let user_id = user_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let mut stmt = conn.prepare(
+                "SELECT * FROM exercises WHERE user_id = ? ORDER BY category, name"
+            )?;
+            let exercises = stmt
+                .query_map([&user_id], |row| Exercise::from_row(row))?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            Ok(exercises)
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
     pub async fn create(
@@ -70,39 +102,53 @@ impl ExerciseRepository {
         user_id: &str,
     ) -> Result<Exercise> {
         let id = Uuid::new_v4().to_string();
-
-        sqlx::query(
-            "INSERT INTO exercises (id, name, category, muscle_group, equipment, is_default, user_id)
-             VALUES (?, ?, ?, ?, ?, 0, ?)"
-        )
-        .bind(&id)
-        .bind(name)
-        .bind(category)
-        .bind(muscle_group)
-        .bind(equipment)
-        .bind(user_id)
-        .execute(&self.pool)
-        .await?;
-
-        Ok(Exercise {
-            id,
+        let exercise = Exercise {
+            id: id.clone(),
             name: name.to_string(),
             category: category.to_string(),
             muscle_group: muscle_group.to_string(),
             equipment: equipment.map(|s| s.to_string()),
             is_default: false,
             user_id: Some(user_id.to_string()),
+        };
+        let exercise_clone = exercise.clone();
+
+        let pool = self.pool.clone();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let conn = pool.get()?;
+            conn.execute(
+                "INSERT INTO exercises (id, name, category, muscle_group, equipment, is_default, user_id)
+                 VALUES (?, ?, ?, ?, ?, 0, ?)",
+                rusqlite::params![
+                    exercise_clone.id,
+                    exercise_clone.name,
+                    exercise_clone.category,
+                    exercise_clone.muscle_group,
+                    exercise_clone.equipment,
+                    exercise_clone.user_id
+                ],
+            )?;
+            Ok(())
         })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))??;
+
+        Ok(exercise)
     }
 
     pub async fn delete(&self, id: &str, user_id: &str) -> Result<bool> {
-        let result = sqlx::query(
-            "DELETE FROM exercises WHERE id = ? AND user_id = ? AND is_default = 0"
-        )
-        .bind(id)
-        .bind(user_id)
-        .execute(&self.pool)
-        .await?;
-        Ok(result.rows_affected() > 0)
+        let pool = self.pool.clone();
+        let id = id.to_string();
+        let user_id = user_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let rows = conn.execute(
+                "DELETE FROM exercises WHERE id = ? AND user_id = ? AND is_default = 0",
+                rusqlite::params![id, user_id],
+            )?;
+            Ok(rows > 0)
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
     }
 }

--- a/src/repositories/mod.rs
+++ b/src/repositories/mod.rs
@@ -1,7 +1,7 @@
-pub mod user_repo;
 pub mod exercise_repo;
+pub mod user_repo;
 pub mod workout_repo;
 
-pub use user_repo::UserRepository;
 pub use exercise_repo::ExerciseRepository;
+pub use user_repo::UserRepository;
 pub use workout_repo::WorkoutRepository;

--- a/src/repositories/user_repo.rs
+++ b/src/repositories/user_repo.rs
@@ -1,75 +1,107 @@
-use sqlx::SqlitePool;
-use uuid::Uuid;
 use chrono::Utc;
+use rusqlite::OptionalExtension;
+use uuid::Uuid;
 use argon2::{
     password_hash::{rand_core::OsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
     Argon2,
 };
 
+use crate::db::DbPool;
 use crate::error::{AppError, Result};
-use crate::models::User;
+use crate::models::{FromSqliteRow, User};
 
 #[derive(Clone)]
 pub struct UserRepository {
-    pool: SqlitePool,
+    pool: DbPool,
 }
 
 impl UserRepository {
-    pub fn new(pool: SqlitePool) -> Self {
+    pub fn new(pool: DbPool) -> Self {
         Self { pool }
     }
 
     pub async fn count(&self) -> Result<i64> {
-        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM users")
-            .fetch_one(&self.pool)
-            .await?;
-        Ok(count.0)
+        let pool = self.pool.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let count: i64 = conn.query_row("SELECT COUNT(*) FROM users", [], |row| row.get(0))?;
+            Ok(count)
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
     pub async fn find_by_id(&self, id: &str) -> Result<Option<User>> {
-        let user = sqlx::query_as::<_, User>("SELECT * FROM users WHERE id = ?")
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await?;
-        Ok(user)
+        let pool = self.pool.clone();
+        let id = id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let mut stmt = conn.prepare("SELECT * FROM users WHERE id = ?")?;
+            let result = stmt
+                .query_row([&id], |row| User::from_row(row))
+                .optional()?;
+            Ok(result)
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
     pub async fn find_by_username(&self, username: &str) -> Result<Option<User>> {
-        let user = sqlx::query_as::<_, User>("SELECT * FROM users WHERE username = ?")
-            .bind(username)
-            .fetch_optional(&self.pool)
-            .await?;
-        Ok(user)
+        let pool = self.pool.clone();
+        let username = username.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let mut stmt = conn.prepare("SELECT * FROM users WHERE username = ?")?;
+            let result = stmt
+                .query_row([&username], |row| User::from_row(row))
+                .optional()?;
+            Ok(result)
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
     pub async fn find_all(&self) -> Result<Vec<User>> {
-        let users = sqlx::query_as::<_, User>("SELECT * FROM users ORDER BY created_at DESC")
-            .fetch_all(&self.pool)
-            .await?;
-        Ok(users)
+        let pool = self.pool.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let mut stmt = conn.prepare("SELECT * FROM users ORDER BY created_at DESC")?;
+            let users = stmt
+                .query_map([], |row| User::from_row(row))?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            Ok(users)
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
     pub async fn create(&self, username: &str, password: &str) -> Result<User> {
         let password_hash = hash_password(password)?;
         let id = Uuid::new_v4().to_string();
         let now = Utc::now();
+        let username = username.to_string();
 
-        sqlx::query(
-            "INSERT INTO users (id, username, password_hash, created_at) VALUES (?, ?, ?, ?)"
-        )
-        .bind(&id)
-        .bind(username)
-        .bind(&password_hash)
-        .bind(now)
-        .execute(&self.pool)
-        .await?;
-
-        Ok(User {
-            id,
-            username: username.to_string(),
+        let pool = self.pool.clone();
+        let user = User {
+            id: id.clone(),
+            username: username.clone(),
             password_hash,
             created_at: now,
+        };
+        let user_clone = user.clone();
+
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let conn = pool.get()?;
+            conn.execute(
+                "INSERT INTO users (id, username, password_hash, created_at) VALUES (?, ?, ?, ?)",
+                rusqlite::params![user_clone.id, user_clone.username, user_clone.password_hash, user_clone.created_at],
+            )?;
+            Ok(())
         })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))??;
+
+        Ok(user)
     }
 
     pub async fn verify_password(&self, username: &str, password: &str) -> Result<Option<User>> {
@@ -88,11 +120,15 @@ impl UserRepository {
     }
 
     pub async fn delete(&self, id: &str) -> Result<bool> {
-        let result = sqlx::query("DELETE FROM users WHERE id = ?")
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
-        Ok(result.rows_affected() > 0)
+        let pool = self.pool.clone();
+        let id = id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let rows = conn.execute("DELETE FROM users WHERE id = ?", [&id])?;
+            Ok(rows > 0)
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
     }
 }
 

--- a/src/repositories/workout_repo.rs
+++ b/src/repositories/workout_repo.rs
@@ -1,19 +1,21 @@
 use chrono::{NaiveDate, Utc};
-use sqlx::SqlitePool;
+use rusqlite::OptionalExtension;
 use uuid::Uuid;
 
-use crate::error::Result;
+use crate::db::DbPool;
+use crate::error::{AppError, Result};
 use crate::models::{
-    PersonalRecord, PersonalRecordWithExercise, WorkoutLog, WorkoutLogWithExercise, WorkoutSession,
+    FromSqliteRow, PersonalRecord, PersonalRecordWithExercise, WorkoutLog, WorkoutLogWithExercise,
+    WorkoutSession,
 };
 
 #[derive(Clone)]
 pub struct WorkoutRepository {
-    pool: SqlitePool,
+    pool: DbPool,
 }
 
 impl WorkoutRepository {
-    pub fn new(pool: SqlitePool) -> Self {
+    pub fn new(pool: DbPool) -> Self {
         Self { pool }
     }
 
@@ -26,45 +28,66 @@ impl WorkoutRepository {
     ) -> Result<WorkoutSession> {
         let id = Uuid::new_v4().to_string();
         let now = Utc::now();
-
-        sqlx::query(
-            "INSERT INTO workout_sessions (id, user_id, date, notes, created_at) VALUES (?, ?, ?, ?, ?)"
-        )
-        .bind(&id)
-        .bind(user_id)
-        .bind(date)
-        .bind(notes)
-        .bind(now)
-        .execute(&self.pool)
-        .await?;
-
-        Ok(WorkoutSession {
-            id,
+        let session = WorkoutSession {
+            id: id.clone(),
             user_id: user_id.to_string(),
             date,
             notes: notes.map(|s| s.to_string()),
             created_at: now,
-        })
-    }
+        };
+        let session_clone = session.clone();
 
-    pub async fn find_session_by_id(&self, id: &str) -> Result<Option<WorkoutSession>> {
-        let session = sqlx::query_as::<_, WorkoutSession>(
-            "SELECT * FROM workout_sessions WHERE id = ?"
-        )
-        .bind(id)
-        .fetch_optional(&self.pool)
-        .await?;
+        let pool = self.pool.clone();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let conn = pool.get()?;
+            conn.execute(
+                "INSERT INTO workout_sessions (id, user_id, date, notes, created_at) VALUES (?, ?, ?, ?, ?)",
+                rusqlite::params![
+                    session_clone.id,
+                    session_clone.user_id,
+                    session_clone.date,
+                    session_clone.notes,
+                    session_clone.created_at
+                ],
+            )?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))??;
+
         Ok(session)
     }
 
+    pub async fn find_session_by_id(&self, id: &str) -> Result<Option<WorkoutSession>> {
+        let pool = self.pool.clone();
+        let id = id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let mut stmt = conn.prepare("SELECT * FROM workout_sessions WHERE id = ?")?;
+            let result = stmt
+                .query_row([&id], |row| WorkoutSession::from_row(row))
+                .optional()?;
+            Ok(result)
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+    }
+
     pub async fn find_sessions_by_user(&self, user_id: &str) -> Result<Vec<WorkoutSession>> {
-        let sessions = sqlx::query_as::<_, WorkoutSession>(
-            "SELECT * FROM workout_sessions WHERE user_id = ? ORDER BY date DESC"
-        )
-        .bind(user_id)
-        .fetch_all(&self.pool)
-        .await?;
-        Ok(sessions)
+        let pool = self.pool.clone();
+        let user_id = user_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let mut stmt = conn.prepare(
+                "SELECT * FROM workout_sessions WHERE user_id = ? ORDER BY date DESC"
+            )?;
+            let sessions = stmt
+                .query_map([&user_id], |row| WorkoutSession::from_row(row))?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            Ok(sessions)
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
     pub async fn find_sessions_by_user_paginated(
@@ -73,25 +96,38 @@ impl WorkoutRepository {
         limit: i64,
         offset: i64,
     ) -> Result<Vec<WorkoutSession>> {
-        let sessions = sqlx::query_as::<_, WorkoutSession>(
-            "SELECT * FROM workout_sessions WHERE user_id = ? ORDER BY date DESC LIMIT ? OFFSET ?"
-        )
-        .bind(user_id)
-        .bind(limit)
-        .bind(offset)
-        .fetch_all(&self.pool)
-        .await?;
-        Ok(sessions)
+        let pool = self.pool.clone();
+        let user_id = user_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let mut stmt = conn.prepare(
+                "SELECT * FROM workout_sessions WHERE user_id = ? ORDER BY date DESC LIMIT ? OFFSET ?"
+            )?;
+            let sessions = stmt
+                .query_map(rusqlite::params![user_id, limit, offset], |row| {
+                    WorkoutSession::from_row(row)
+                })?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            Ok(sessions)
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
     pub async fn count_sessions_by_user(&self, user_id: &str) -> Result<i64> {
-        let count: (i64,) = sqlx::query_as(
-            "SELECT COUNT(*) FROM workout_sessions WHERE user_id = ?"
-        )
-        .bind(user_id)
-        .fetch_one(&self.pool)
-        .await?;
-        Ok(count.0)
+        let pool = self.pool.clone();
+        let user_id = user_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let count: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM workout_sessions WHERE user_id = ?",
+                [&user_id],
+                |row| row.get(0),
+            )?;
+            Ok(count)
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
     pub async fn update_session(
@@ -101,36 +137,44 @@ impl WorkoutRepository {
         date: Option<NaiveDate>,
         notes: Option<&str>,
     ) -> Result<bool> {
-        let mut query = String::from("UPDATE workout_sessions SET ");
-        let mut updates = Vec::new();
+        let pool = self.pool.clone();
+        let id = id.to_string();
+        let user_id = user_id.to_string();
+        let notes = notes.map(|s| s.to_string());
 
-        if date.is_some() {
-            updates.push("date = ?");
-        }
-        updates.push("notes = ?");
-
-        query.push_str(&updates.join(", "));
-        query.push_str(" WHERE id = ? AND user_id = ?");
-
-        let mut q = sqlx::query(&query);
-        if let Some(d) = date {
-            q = q.bind(d);
-        }
-        q = q.bind(notes).bind(id).bind(user_id);
-
-        let result = q.execute(&self.pool).await?;
-        Ok(result.rows_affected() > 0)
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let rows = if let Some(d) = date {
+                conn.execute(
+                    "UPDATE workout_sessions SET date = ?, notes = ? WHERE id = ? AND user_id = ?",
+                    rusqlite::params![d, notes, id, user_id],
+                )?
+            } else {
+                conn.execute(
+                    "UPDATE workout_sessions SET notes = ? WHERE id = ? AND user_id = ?",
+                    rusqlite::params![notes, id, user_id],
+                )?
+            };
+            Ok(rows > 0)
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
     pub async fn delete_session(&self, id: &str, user_id: &str) -> Result<bool> {
-        let result = sqlx::query(
-            "DELETE FROM workout_sessions WHERE id = ? AND user_id = ?"
-        )
-        .bind(id)
-        .bind(user_id)
-        .execute(&self.pool)
-        .await?;
-        Ok(result.rows_affected() > 0)
+        let pool = self.pool.clone();
+        let id = id.to_string();
+        let user_id = user_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let rows = conn.execute(
+                "DELETE FROM workout_sessions WHERE id = ? AND user_id = ?",
+                rusqlite::params![id, user_id],
+            )?;
+            Ok(rows > 0)
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
     // Workout Logs
@@ -145,24 +189,8 @@ impl WorkoutRepository {
     ) -> Result<WorkoutLog> {
         let id = Uuid::new_v4().to_string();
         let now = Utc::now();
-
-        sqlx::query(
-            "INSERT INTO workout_logs (id, session_id, exercise_id, set_number, reps, weight, rpe, is_pr, created_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?)"
-        )
-        .bind(&id)
-        .bind(session_id)
-        .bind(exercise_id)
-        .bind(set_number)
-        .bind(reps)
-        .bind(weight)
-        .bind(rpe)
-        .bind(now)
-        .execute(&self.pool)
-        .await?;
-
-        Ok(WorkoutLog {
-            id,
+        let log = WorkoutLog {
+            id: id.clone(),
             session_id: session_id.to_string(),
             exercise_id: exercise_id.to_string(),
             set_number,
@@ -171,63 +199,117 @@ impl WorkoutRepository {
             rpe,
             is_pr: false,
             created_at: now,
+        };
+        let log_clone = log.clone();
+
+        let pool = self.pool.clone();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let conn = pool.get()?;
+            conn.execute(
+                "INSERT INTO workout_logs (id, session_id, exercise_id, set_number, reps, weight, rpe, is_pr, created_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?)",
+                rusqlite::params![
+                    log_clone.id,
+                    log_clone.session_id,
+                    log_clone.exercise_id,
+                    log_clone.set_number,
+                    log_clone.reps,
+                    log_clone.weight,
+                    log_clone.rpe,
+                    log_clone.created_at
+                ],
+            )?;
+            Ok(())
         })
-    }
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))??;
 
-    pub async fn find_logs_by_session(&self, session_id: &str) -> Result<Vec<WorkoutLogWithExercise>> {
-        let logs = sqlx::query_as::<_, WorkoutLogWithExercise>(
-            "SELECT wl.id, wl.session_id, wl.exercise_id, e.name as exercise_name,
-                    wl.set_number, wl.reps, wl.weight, wl.rpe, wl.is_pr
-             FROM workout_logs wl
-             JOIN exercises e ON wl.exercise_id = e.id
-             WHERE wl.session_id = ?
-             ORDER BY wl.created_at, wl.set_number"
-        )
-        .bind(session_id)
-        .fetch_all(&self.pool)
-        .await?;
-        Ok(logs)
-    }
-
-    pub async fn find_log_by_id(&self, id: &str) -> Result<Option<WorkoutLog>> {
-        let log = sqlx::query_as::<_, WorkoutLog>(
-            "SELECT * FROM workout_logs WHERE id = ?"
-        )
-        .bind(id)
-        .fetch_optional(&self.pool)
-        .await?;
         Ok(log)
     }
 
+    pub async fn find_logs_by_session(&self, session_id: &str) -> Result<Vec<WorkoutLogWithExercise>> {
+        let pool = self.pool.clone();
+        let session_id = session_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let mut stmt = conn.prepare(
+                "SELECT wl.id, wl.session_id, wl.exercise_id, e.name as exercise_name,
+                        wl.set_number, wl.reps, wl.weight, wl.rpe, wl.is_pr
+                 FROM workout_logs wl
+                 JOIN exercises e ON wl.exercise_id = e.id
+                 WHERE wl.session_id = ?
+                 ORDER BY wl.created_at, wl.set_number"
+            )?;
+            let logs = stmt
+                .query_map([&session_id], |row| WorkoutLogWithExercise::from_row(row))?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            Ok(logs)
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+    }
+
+    pub async fn find_log_by_id(&self, id: &str) -> Result<Option<WorkoutLog>> {
+        let pool = self.pool.clone();
+        let id = id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let mut stmt = conn.prepare("SELECT * FROM workout_logs WHERE id = ?")?;
+            let result = stmt
+                .query_row([&id], |row| WorkoutLog::from_row(row))
+                .optional()?;
+            Ok(result)
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+    }
+
     pub async fn delete_log(&self, id: &str, session_id: &str) -> Result<bool> {
-        let result = sqlx::query(
-            "DELETE FROM workout_logs WHERE id = ? AND session_id = ?"
-        )
-        .bind(id)
-        .bind(session_id)
-        .execute(&self.pool)
-        .await?;
-        Ok(result.rows_affected() > 0)
+        let pool = self.pool.clone();
+        let id = id.to_string();
+        let session_id = session_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let rows = conn.execute(
+                "DELETE FROM workout_logs WHERE id = ? AND session_id = ?",
+                rusqlite::params![id, session_id],
+            )?;
+            Ok(rows > 0)
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
     pub async fn mark_as_pr(&self, id: &str) -> Result<bool> {
-        let result = sqlx::query("UPDATE workout_logs SET is_pr = 1 WHERE id = ?")
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
-        Ok(result.rows_affected() > 0)
+        let pool = self.pool.clone();
+        let id = id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let rows = conn.execute("UPDATE workout_logs SET is_pr = 1 WHERE id = ?", [&id])?;
+            Ok(rows > 0)
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
     pub async fn get_next_set_number(&self, session_id: &str, exercise_id: &str) -> Result<i32> {
-        let result: Option<(i32,)> = sqlx::query_as(
-            "SELECT MAX(set_number) FROM workout_logs WHERE session_id = ? AND exercise_id = ?"
-        )
-        .bind(session_id)
-        .bind(exercise_id)
-        .fetch_optional(&self.pool)
-        .await?;
-
-        Ok(result.map(|(n,)| n + 1).unwrap_or(1))
+        let pool = self.pool.clone();
+        let session_id = session_id.to_string();
+        let exercise_id = exercise_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let result: Option<i32> = conn
+                .query_row(
+                    "SELECT MAX(set_number) FROM workout_logs WHERE session_id = ? AND exercise_id = ?",
+                    rusqlite::params![session_id, exercise_id],
+                    |row| row.get(0),
+                )
+                .optional()?
+                .flatten();
+            Ok(result.map(|n| n + 1).unwrap_or(1))
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
     // Personal Records
@@ -237,15 +319,25 @@ impl WorkoutRepository {
         exercise_id: &str,
         record_type: &str,
     ) -> Result<Option<PersonalRecord>> {
-        let pr = sqlx::query_as::<_, PersonalRecord>(
-            "SELECT * FROM personal_records WHERE user_id = ? AND exercise_id = ? AND record_type = ?"
-        )
-        .bind(user_id)
-        .bind(exercise_id)
-        .bind(record_type)
-        .fetch_optional(&self.pool)
-        .await?;
-        Ok(pr)
+        let pool = self.pool.clone();
+        let user_id = user_id.to_string();
+        let exercise_id = exercise_id.to_string();
+        let record_type = record_type.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let mut stmt = conn.prepare(
+                "SELECT * FROM personal_records WHERE user_id = ? AND exercise_id = ? AND record_type = ?"
+            )?;
+            let result = stmt
+                .query_row(
+                    rusqlite::params![user_id, exercise_id, record_type],
+                    |row| PersonalRecord::from_row(row),
+                )
+                .optional()?;
+            Ok(result)
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
     pub async fn upsert_pr(
@@ -257,45 +349,61 @@ impl WorkoutRepository {
     ) -> Result<PersonalRecord> {
         let id = Uuid::new_v4().to_string();
         let now = Utc::now();
-
-        sqlx::query(
-            "INSERT INTO personal_records (id, user_id, exercise_id, record_type, value, achieved_at)
-             VALUES (?, ?, ?, ?, ?, ?)
-             ON CONFLICT(user_id, exercise_id, record_type)
-             DO UPDATE SET value = excluded.value, achieved_at = excluded.achieved_at"
-        )
-        .bind(&id)
-        .bind(user_id)
-        .bind(exercise_id)
-        .bind(record_type)
-        .bind(value)
-        .bind(now)
-        .execute(&self.pool)
-        .await?;
-
-        Ok(PersonalRecord {
-            id,
+        let pr = PersonalRecord {
+            id: id.clone(),
             user_id: user_id.to_string(),
             exercise_id: exercise_id.to_string(),
             record_type: record_type.to_string(),
             value,
             achieved_at: now,
+        };
+        let pr_clone = pr.clone();
+
+        let pool = self.pool.clone();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let conn = pool.get()?;
+            conn.execute(
+                "INSERT INTO personal_records (id, user_id, exercise_id, record_type, value, achieved_at)
+                 VALUES (?, ?, ?, ?, ?, ?)
+                 ON CONFLICT(user_id, exercise_id, record_type)
+                 DO UPDATE SET value = excluded.value, achieved_at = excluded.achieved_at",
+                rusqlite::params![
+                    pr_clone.id,
+                    pr_clone.user_id,
+                    pr_clone.exercise_id,
+                    pr_clone.record_type,
+                    pr_clone.value,
+                    pr_clone.achieved_at
+                ],
+            )?;
+            Ok(())
         })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))??;
+
+        Ok(pr)
     }
 
     pub async fn find_prs_by_user(&self, user_id: &str) -> Result<Vec<PersonalRecordWithExercise>> {
-        let prs = sqlx::query_as::<_, PersonalRecordWithExercise>(
-            "SELECT pr.id, pr.user_id, pr.exercise_id, e.name as exercise_name,
-                    pr.record_type, pr.value, pr.achieved_at
-             FROM personal_records pr
-             JOIN exercises e ON pr.exercise_id = e.id
-             WHERE pr.user_id = ?
-             ORDER BY pr.achieved_at DESC"
-        )
-        .bind(user_id)
-        .fetch_all(&self.pool)
-        .await?;
-        Ok(prs)
+        let pool = self.pool.clone();
+        let user_id = user_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let mut stmt = conn.prepare(
+                "SELECT pr.id, pr.user_id, pr.exercise_id, e.name as exercise_name,
+                        pr.record_type, pr.value, pr.achieved_at
+                 FROM personal_records pr
+                 JOIN exercises e ON pr.exercise_id = e.id
+                 WHERE pr.user_id = ?
+                 ORDER BY pr.achieved_at DESC"
+            )?;
+            let prs = stmt
+                .query_map([&user_id], |row| PersonalRecordWithExercise::from_row(row))?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            Ok(prs)
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
     pub async fn find_prs_by_exercise(
@@ -303,52 +411,82 @@ impl WorkoutRepository {
         user_id: &str,
         exercise_id: &str,
     ) -> Result<Vec<PersonalRecord>> {
-        let prs = sqlx::query_as::<_, PersonalRecord>(
-            "SELECT * FROM personal_records
-             WHERE user_id = ? AND exercise_id = ?
-             ORDER BY record_type"
-        )
-        .bind(user_id)
-        .bind(exercise_id)
-        .fetch_all(&self.pool)
-        .await?;
-        Ok(prs)
+        let pool = self.pool.clone();
+        let user_id = user_id.to_string();
+        let exercise_id = exercise_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let mut stmt = conn.prepare(
+                "SELECT * FROM personal_records
+                 WHERE user_id = ? AND exercise_id = ?
+                 ORDER BY record_type"
+            )?;
+            let prs = stmt
+                .query_map(rusqlite::params![user_id, exercise_id], |row| {
+                    PersonalRecord::from_row(row)
+                })?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            Ok(prs)
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
     // Statistics
     pub async fn count_workouts_this_week(&self, user_id: &str) -> Result<i64> {
-        let count: (i64,) = sqlx::query_as(
-            "SELECT COUNT(*) FROM workout_sessions
-             WHERE user_id = ? AND date >= date('now', '-7 days')"
-        )
-        .bind(user_id)
-        .fetch_one(&self.pool)
-        .await?;
-        Ok(count.0)
+        let pool = self.pool.clone();
+        let user_id = user_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let count: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM workout_sessions
+                 WHERE user_id = ? AND date >= date('now', '-7 days')",
+                [&user_id],
+                |row| row.get(0),
+            )?;
+            Ok(count)
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
     pub async fn count_workouts_this_month(&self, user_id: &str) -> Result<i64> {
-        let count: (i64,) = sqlx::query_as(
-            "SELECT COUNT(*) FROM workout_sessions
-             WHERE user_id = ? AND date >= date('now', '-30 days')"
-        )
-        .bind(user_id)
-        .fetch_one(&self.pool)
-        .await?;
-        Ok(count.0)
+        let pool = self.pool.clone();
+        let user_id = user_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let count: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM workout_sessions
+                 WHERE user_id = ? AND date >= date('now', '-30 days')",
+                [&user_id],
+                |row| row.get(0),
+            )?;
+            Ok(count)
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
     pub async fn get_total_volume_this_week(&self, user_id: &str) -> Result<f64> {
-        let result: Option<(f64,)> = sqlx::query_as(
-            "SELECT SUM(wl.weight * wl.reps)
-             FROM workout_logs wl
-             JOIN workout_sessions ws ON wl.session_id = ws.id
-             WHERE ws.user_id = ? AND ws.date >= date('now', '-7 days')"
-        )
-        .bind(user_id)
-        .fetch_optional(&self.pool)
-        .await?;
-        Ok(result.map(|(v,)| v).unwrap_or(0.0))
+        let pool = self.pool.clone();
+        let user_id = user_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let result: Option<f64> = conn
+                .query_row(
+                    "SELECT SUM(wl.weight * wl.reps)
+                     FROM workout_logs wl
+                     JOIN workout_sessions ws ON wl.session_id = ws.id
+                     WHERE ws.user_id = ? AND ws.date >= date('now', '-7 days')",
+                    [&user_id],
+                    |row| row.get(0),
+                )
+                .optional()?
+                .flatten();
+            Ok(result.unwrap_or(0.0))
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
     pub async fn get_exercise_history(
@@ -357,18 +495,26 @@ impl WorkoutRepository {
         exercise_id: &str,
         limit: i64,
     ) -> Result<Vec<WorkoutLog>> {
-        let logs = sqlx::query_as::<_, WorkoutLog>(
-            "SELECT wl.* FROM workout_logs wl
-             JOIN workout_sessions ws ON wl.session_id = ws.id
-             WHERE ws.user_id = ? AND wl.exercise_id = ?
-             ORDER BY ws.date DESC, wl.set_number
-             LIMIT ?"
-        )
-        .bind(user_id)
-        .bind(exercise_id)
-        .bind(limit)
-        .fetch_all(&self.pool)
-        .await?;
-        Ok(logs)
+        let pool = self.pool.clone();
+        let user_id = user_id.to_string();
+        let exercise_id = exercise_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let mut stmt = conn.prepare(
+                "SELECT wl.* FROM workout_logs wl
+                 JOIN workout_sessions ws ON wl.session_id = ws.id
+                 WHERE ws.user_id = ? AND wl.exercise_id = ?
+                 ORDER BY ws.date DESC, wl.set_number
+                 LIMIT ?"
+            )?;
+            let logs = stmt
+                .query_map(rusqlite::params![user_id, exercise_id, limit], |row| {
+                    WorkoutLog::from_row(row)
+                })?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            Ok(logs)
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
     }
 }

--- a/src/repositories/workout_repo.rs
+++ b/src/repositories/workout_repo.rs
@@ -64,25 +64,23 @@ impl WorkoutRepository {
         tokio::task::spawn_blocking(move || {
             let conn = pool.get()?;
             let mut stmt = conn.prepare("SELECT * FROM workout_sessions WHERE id = ?")?;
-            let result = stmt
-                .query_row([&id], |row| WorkoutSession::from_row(row))
-                .optional()?;
+            let result = stmt.query_row([&id], WorkoutSession::from_row).optional()?;
             Ok(result)
         })
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
+    #[allow(dead_code)]
     pub async fn find_sessions_by_user(&self, user_id: &str) -> Result<Vec<WorkoutSession>> {
         let pool = self.pool.clone();
         let user_id = user_id.to_string();
         tokio::task::spawn_blocking(move || {
             let conn = pool.get()?;
-            let mut stmt = conn.prepare(
-                "SELECT * FROM workout_sessions WHERE user_id = ? ORDER BY date DESC"
-            )?;
+            let mut stmt = conn
+                .prepare("SELECT * FROM workout_sessions WHERE user_id = ? ORDER BY date DESC")?;
             let sessions = stmt
-                .query_map([&user_id], |row| WorkoutSession::from_row(row))?
+                .query_map([&user_id], WorkoutSession::from_row)?
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             Ok(sessions)
         })
@@ -104,9 +102,7 @@ impl WorkoutRepository {
                 "SELECT * FROM workout_sessions WHERE user_id = ? ORDER BY date DESC LIMIT ? OFFSET ?"
             )?;
             let sessions = stmt
-                .query_map(rusqlite::params![user_id, limit, offset], |row| {
-                    WorkoutSession::from_row(row)
-                })?
+                .query_map(rusqlite::params![user_id, limit, offset], WorkoutSession::from_row)?
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             Ok(sessions)
         })
@@ -227,7 +223,10 @@ impl WorkoutRepository {
         Ok(log)
     }
 
-    pub async fn find_logs_by_session(&self, session_id: &str) -> Result<Vec<WorkoutLogWithExercise>> {
+    pub async fn find_logs_by_session(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<WorkoutLogWithExercise>> {
         let pool = self.pool.clone();
         let session_id = session_id.to_string();
         tokio::task::spawn_blocking(move || {
@@ -238,10 +237,10 @@ impl WorkoutRepository {
                  FROM workout_logs wl
                  JOIN exercises e ON wl.exercise_id = e.id
                  WHERE wl.session_id = ?
-                 ORDER BY wl.created_at, wl.set_number"
+                 ORDER BY wl.created_at, wl.set_number",
             )?;
             let logs = stmt
-                .query_map([&session_id], |row| WorkoutLogWithExercise::from_row(row))?
+                .query_map([&session_id], WorkoutLogWithExercise::from_row)?
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             Ok(logs)
         })
@@ -249,15 +248,14 @@ impl WorkoutRepository {
         .map_err(|e| AppError::Internal(e.to_string()))?
     }
 
+    #[allow(dead_code)]
     pub async fn find_log_by_id(&self, id: &str) -> Result<Option<WorkoutLog>> {
         let pool = self.pool.clone();
         let id = id.to_string();
         tokio::task::spawn_blocking(move || {
             let conn = pool.get()?;
             let mut stmt = conn.prepare("SELECT * FROM workout_logs WHERE id = ?")?;
-            let result = stmt
-                .query_row([&id], |row| WorkoutLog::from_row(row))
-                .optional()?;
+            let result = stmt.query_row([&id], WorkoutLog::from_row).optional()?;
             Ok(result)
         })
         .await
@@ -331,7 +329,7 @@ impl WorkoutRepository {
             let result = stmt
                 .query_row(
                     rusqlite::params![user_id, exercise_id, record_type],
-                    |row| PersonalRecord::from_row(row),
+                    PersonalRecord::from_row,
                 )
                 .optional()?;
             Ok(result)
@@ -395,10 +393,10 @@ impl WorkoutRepository {
                  FROM personal_records pr
                  JOIN exercises e ON pr.exercise_id = e.id
                  WHERE pr.user_id = ?
-                 ORDER BY pr.achieved_at DESC"
+                 ORDER BY pr.achieved_at DESC",
             )?;
             let prs = stmt
-                .query_map([&user_id], |row| PersonalRecordWithExercise::from_row(row))?
+                .query_map([&user_id], PersonalRecordWithExercise::from_row)?
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             Ok(prs)
         })
@@ -419,12 +417,13 @@ impl WorkoutRepository {
             let mut stmt = conn.prepare(
                 "SELECT * FROM personal_records
                  WHERE user_id = ? AND exercise_id = ?
-                 ORDER BY record_type"
+                 ORDER BY record_type",
             )?;
             let prs = stmt
-                .query_map(rusqlite::params![user_id, exercise_id], |row| {
-                    PersonalRecord::from_row(row)
-                })?
+                .query_map(
+                    rusqlite::params![user_id, exercise_id],
+                    PersonalRecord::from_row,
+                )?
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             Ok(prs)
         })
@@ -505,12 +504,13 @@ impl WorkoutRepository {
                  JOIN workout_sessions ws ON wl.session_id = ws.id
                  WHERE ws.user_id = ? AND wl.exercise_id = ?
                  ORDER BY ws.date DESC, wl.set_number
-                 LIMIT ?"
+                 LIMIT ?",
             )?;
             let logs = stmt
-                .query_map(rusqlite::params![user_id, exercise_id, limit], |row| {
-                    WorkoutLog::from_row(row)
-                })?
+                .query_map(
+                    rusqlite::params![user_id, exercise_id, limit],
+                    WorkoutLog::from_row,
+                )?
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             Ok(logs)
         })

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,9 +1,10 @@
 use axum::{
     routing::{get, post},
-    Router,
+    Extension, Router,
 };
 
 use crate::handlers::{auth, dashboard, exercises, stats, workouts};
+use crate::session::SessionKey;
 
 pub fn create_router(
     auth_state: auth::AuthState,
@@ -11,6 +12,7 @@ pub fn create_router(
     workouts_state: workouts::WorkoutsState,
     exercises_state: exercises::ExercisesState,
     stats_state: stats::StatsState,
+    session_key: SessionKey,
 ) -> Router {
     Router::new()
         // Dashboard
@@ -44,4 +46,6 @@ pub fn create_router(
         .route("/stats/exercise/:id", get(stats::exercise_stats))
         .route("/stats/prs", get(stats::prs_list))
         .with_state(stats_state)
+        // Session key via Extension layer
+        .layer(Extension(session_key))
 }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -19,11 +19,20 @@ pub fn create_router(
         .route("/", get(dashboard::index))
         .with_state(dashboard_state)
         // Auth routes
-        .route("/auth/login", get(auth::login_page).post(auth::login_submit))
-        .route("/auth/setup", get(auth::setup_page).post(auth::setup_submit))
+        .route(
+            "/auth/login",
+            get(auth::login_page).post(auth::login_submit),
+        )
+        .route(
+            "/auth/setup",
+            get(auth::setup_page).post(auth::setup_submit),
+        )
         .route("/auth/logout", post(auth::logout))
         .route("/users", get(auth::users_list))
-        .route("/users/new", get(auth::new_user_page).post(auth::new_user_submit))
+        .route(
+            "/users/new",
+            get(auth::new_user_page).post(auth::new_user_submit),
+        )
         .with_state(auth_state)
         // Workout routes
         .route("/workouts", get(workouts::list))
@@ -34,7 +43,10 @@ pub fn create_router(
         .route("/workouts/:id", post(workouts::update))
         .route("/workouts/:id/delete", post(workouts::delete))
         .route("/workouts/:id/logs", post(workouts::add_log))
-        .route("/workouts/:id/logs/:log_id/delete", post(workouts::delete_log))
+        .route(
+            "/workouts/:id/logs/:log_id/delete",
+            post(workouts::delete_log),
+        )
         .with_state(workouts_state)
         // Exercise routes
         .route("/exercises", get(exercises::list))

--- a/src/session.rs
+++ b/src/session.rs
@@ -11,6 +11,7 @@ impl SessionKey {
         Self(Key::generate())
     }
 
+    #[allow(dead_code)]
     pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
         Key::try_from(bytes).ok().map(Self)
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,0 +1,58 @@
+use axum_extra::extract::cookie::{Cookie, Key, SignedCookieJar};
+use serde::{Deserialize, Serialize};
+
+pub const SESSION_COOKIE_NAME: &str = "session";
+
+#[derive(Clone)]
+pub struct SessionKey(pub Key);
+
+impl SessionKey {
+    pub fn generate() -> Self {
+        Self(Key::generate())
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        Key::try_from(bytes).ok().map(Self)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionData {
+    pub user_id: String,
+    pub username: String,
+}
+
+impl SessionData {
+    pub fn new(user_id: String, username: String) -> Self {
+        Self { user_id, username }
+    }
+
+    pub fn to_cookie_value(&self) -> String {
+        serde_json::to_string(self).unwrap_or_default()
+    }
+
+    pub fn from_cookie_value(value: &str) -> Option<Self> {
+        serde_json::from_str(value).ok()
+    }
+}
+
+pub fn create_session_cookie(data: &SessionData) -> Cookie<'static> {
+    Cookie::build((SESSION_COOKIE_NAME, data.to_cookie_value()))
+        .path("/")
+        .http_only(true)
+        .same_site(axum_extra::extract::cookie::SameSite::Lax)
+        .max_age(time::Duration::days(7))
+        .build()
+}
+
+pub fn get_session_from_jar(jar: &SignedCookieJar) -> Option<SessionData> {
+    jar.get(SESSION_COOKIE_NAME)
+        .and_then(|cookie| SessionData::from_cookie_value(cookie.value()))
+}
+
+pub fn remove_session_cookie() -> Cookie<'static> {
+    Cookie::build((SESSION_COOKIE_NAME, ""))
+        .path("/")
+        .max_age(time::Duration::ZERO)
+        .build()
+}

--- a/tests/auth_test.rs
+++ b/tests/auth_test.rs
@@ -22,10 +22,7 @@ async fn test_login_page_redirects_to_setup_when_no_users() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::SEE_OTHER);
-    assert_eq!(
-        response.headers().get("location").unwrap(),
-        "/auth/setup"
-    );
+    assert_eq!(response.headers().get("location").unwrap(), "/auth/setup");
 }
 
 #[tokio::test]
@@ -52,19 +49,11 @@ async fn test_dashboard_requires_auth() {
     let app = common::create_test_app(pool);
 
     let response = app
-        .oneshot(
-            Request::builder()
-                .uri("/")
-                .body(Body::empty())
-                .unwrap(),
-        )
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
         .await
         .unwrap();
 
     // Should redirect to login
     assert_eq!(response.status(), StatusCode::SEE_OTHER);
-    assert_eq!(
-        response.headers().get("location").unwrap(),
-        "/auth/login"
-    );
+    assert_eq!(response.headers().get("location").unwrap(), "/auth/login");
 }

--- a/tests/auth_test.rs
+++ b/tests/auth_test.rs
@@ -8,8 +8,8 @@ use tower::ServiceExt;
 
 #[tokio::test]
 async fn test_login_page_redirects_to_setup_when_no_users() {
-    let pool = common::setup_test_db().await;
-    let app = common::create_test_app(pool).await;
+    let pool = common::setup_test_db();
+    let app = common::create_test_app(pool);
 
     let response = app
         .oneshot(
@@ -30,8 +30,8 @@ async fn test_login_page_redirects_to_setup_when_no_users() {
 
 #[tokio::test]
 async fn test_setup_page_available_when_no_users() {
-    let pool = common::setup_test_db().await;
-    let app = common::create_test_app(pool).await;
+    let pool = common::setup_test_db();
+    let app = common::create_test_app(pool);
 
     let response = app
         .oneshot(
@@ -48,8 +48,8 @@ async fn test_setup_page_available_when_no_users() {
 
 #[tokio::test]
 async fn test_dashboard_requires_auth() {
-    let pool = common::setup_test_db().await;
-    let app = common::create_test_app(pool).await;
+    let pool = common::setup_test_db();
+    let app = common::create_test_app(pool);
 
     let response = app
         .oneshot(

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -19,7 +19,12 @@ fn run_migrations(pool: &DbPool) -> Result<(), Box<dyn std::error::Error>> {
     let migrations_dir = PathBuf::from("migrations");
     let mut entries: Vec<_> = std::fs::read_dir(&migrations_dir)?
         .filter_map(|e| e.ok())
-        .filter(|e| e.path().extension().map(|ext| ext == "sql").unwrap_or(false))
+        .filter(|e| {
+            e.path()
+                .extension()
+                .map(|ext| ext == "sql")
+                .unwrap_or(false)
+        })
         .collect();
 
     entries.sort_by_key(|e| e.file_name());

--- a/tests/stats_test.rs
+++ b/tests/stats_test.rs
@@ -23,10 +23,7 @@ async fn test_stats_requires_auth() {
 
     // Should redirect to login
     assert_eq!(response.status(), StatusCode::SEE_OTHER);
-    assert_eq!(
-        response.headers().get("location").unwrap(),
-        "/auth/login"
-    );
+    assert_eq!(response.headers().get("location").unwrap(), "/auth/login");
 }
 
 #[tokio::test]

--- a/tests/stats_test.rs
+++ b/tests/stats_test.rs
@@ -8,8 +8,8 @@ use tower::ServiceExt;
 
 #[tokio::test]
 async fn test_stats_requires_auth() {
-    let pool = common::setup_test_db().await;
-    let app = common::create_test_app(pool).await;
+    let pool = common::setup_test_db();
+    let app = common::create_test_app(pool);
 
     let response = app
         .oneshot(
@@ -31,8 +31,8 @@ async fn test_stats_requires_auth() {
 
 #[tokio::test]
 async fn test_prs_requires_auth() {
-    let pool = common::setup_test_db().await;
-    let app = common::create_test_app(pool).await;
+    let pool = common::setup_test_db();
+    let app = common::create_test_app(pool);
 
     let response = app
         .oneshot(

--- a/tests/workout_test.rs
+++ b/tests/workout_test.rs
@@ -23,10 +23,7 @@ async fn test_workouts_list_requires_auth() {
 
     // Should redirect to login
     assert_eq!(response.status(), StatusCode::SEE_OTHER);
-    assert_eq!(
-        response.headers().get("location").unwrap(),
-        "/auth/login"
-    );
+    assert_eq!(response.headers().get("location").unwrap(), "/auth/login");
 }
 
 #[tokio::test]

--- a/tests/workout_test.rs
+++ b/tests/workout_test.rs
@@ -8,8 +8,8 @@ use tower::ServiceExt;
 
 #[tokio::test]
 async fn test_workouts_list_requires_auth() {
-    let pool = common::setup_test_db().await;
-    let app = common::create_test_app(pool).await;
+    let pool = common::setup_test_db();
+    let app = common::create_test_app(pool);
 
     let response = app
         .oneshot(
@@ -31,8 +31,8 @@ async fn test_workouts_list_requires_auth() {
 
 #[tokio::test]
 async fn test_new_workout_requires_auth() {
-    let pool = common::setup_test_db().await;
-    let app = common::create_test_app(pool).await;
+    let pool = common::setup_test_db();
+    let app = common::create_test_app(pool);
 
     let response = app
         .oneshot(


### PR DESCRIPTION
## Summary

- Replace async sqlx with synchronous rusqlite using r2d2 connection pooling
- Replace tower-sessions with cookie-based session management using axum-extra's SignedCookieJar
- Fix database URL parsing to strip query parameters before creating file path
- Fix form deserialization errors for workout log creation
- Add CI/CD workflows and Docker support

## Changes

### Dependencies
- Add: rusqlite, r2d2, r2d2_sqlite, axum-extra, serde_json
- Remove: sqlx, tower-sessions, tower-sessions-sqlx-store

### Architecture
- Create `src/db.rs` with r2d2 connection pool wrapper
- Create `src/session.rs` for cookie-based session management
- Create `FromSqliteRow` trait for model deserialization
- Wrap all database operations with `tokio::task::spawn_blocking`
- Use `Extension<SessionKey>` for sharing session key across routes

### Bug Fixes
- Remove unused `set_number` field from `CreateWorkoutLog` (was causing "missing field" error)
- Add custom deserializer for optional `rpe` field to handle empty strings from HTML forms

### CI/CD & Documentation
- Add GitHub Actions CI workflow with multi-platform testing (Ubuntu, Windows, macOS)
- Add Docker workflow for building and pushing to GHCR (amd64 + arm64)
- Add multi-stage Dockerfile with cargo-chef optimization and distroless base image
- Add README.md with usage instructions, configuration, and Docker Compose example

## Test plan

- [x] All existing tests pass (7 tests)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] Manual testing: user registration/login/logout
- [x] Manual testing: create workout sessions and logs
- [x] Manual testing: view statistics and personal records

🤖 Generated with [Claude Code](https://claude.com/claude-code)