### PR TITLE
docs: add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # LiftLog
 
+[![CI](https://github.com/henry40408/liftlog/actions/workflows/ci.yml/badge.svg)](https://github.com/henry40408/liftlog/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Rust](https://img.shields.io/badge/rust-stable-blue.svg)](https://www.rust-lang.org/)
+[![Docker](https://img.shields.io/badge/docker-ghcr.io-blue.svg)](https://ghcr.io/henry40408/liftlog)
+
 A self-hosted workout logging application built with Rust. Track your training sessions, monitor progress, and celebrate personal records.
 
 ## Features


### PR DESCRIPTION
## Summary
- Add CI status badge showing build status
- Add MIT license badge
- Add Rust version badge
- Add Docker registry badge linking to ghcr.io

## Test plan
- [x] Verify badges render correctly in README preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)