### PR TITLE
feat: add user roles with admin/user permissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,6 +872,8 @@ dependencies = [
  "axum-extra",
  "chrono",
  "dotenvy",
+ "http",
+ "http-body-util",
  "r2d2",
  "r2d2_sqlite",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,5 @@ rand = "0.8"
 
 [dev-dependencies]
 tokio-test = "0.4"
+http-body-util = "0.1"
+http = "1"

--- a/migrations/007_add_user_role.sql
+++ b/migrations/007_add_user_role.sql
@@ -1,0 +1,5 @@
+-- Add role column to users table
+ALTER TABLE users ADD COLUMN role TEXT NOT NULL DEFAULT 'user';
+
+-- Set the first user (by created_at) as admin
+UPDATE users SET role = 'admin' WHERE id = (SELECT id FROM users ORDER BY created_at ASC LIMIT 1);

--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -1,6 +1,6 @@
 use askama::Template;
 use axum::{
-    extract::State,
+    extract::{Path, State},
     http::HeaderMap,
     response::{Html, IntoResponse, Redirect, Response},
     Extension, Form,
@@ -8,8 +8,8 @@ use axum::{
 use axum_extra::extract::cookie::SignedCookieJar;
 
 use crate::error::{AppError, Result};
-use crate::middleware::{auth::OptionalAuthUser, AuthUser};
-use crate::models::{CreateUser, LoginCredentials, User};
+use crate::middleware::{auth::OptionalAuthUser, AdminUser, AuthUser};
+use crate::models::{CreateUser, LoginCredentials, User, UserRole};
 use crate::repositories::UserRepository;
 use crate::session::SessionKey;
 
@@ -43,6 +43,7 @@ struct NewUserTemplate {
 struct UsersListTemplate {
     user: AuthUser,
     users: Vec<User>,
+    is_admin: bool,
 }
 
 // Handlers
@@ -166,10 +167,10 @@ pub async fn setup_submit(
             .into_response());
     }
 
-    // Create the first user (admin)
+    // Create the first user as admin
     let user = state
         .user_repo
-        .create(&form.username, &form.password)
+        .create(&form.username, &form.password, UserRole::Admin)
         .await?;
 
     // Auto login
@@ -184,9 +185,9 @@ pub async fn logout(Extension(key): Extension<SessionKey>, headers: HeaderMap) -
     (jar, Redirect::to("/auth/login")).into_response()
 }
 
-pub async fn new_user_page(auth_user: AuthUser) -> Result<Response> {
+pub async fn new_user_page(admin_user: AdminUser) -> Result<Response> {
     let template = NewUserTemplate {
-        user: auth_user,
+        user: admin_user.0,
         error: None,
     };
     Ok(Html(
@@ -199,13 +200,13 @@ pub async fn new_user_page(auth_user: AuthUser) -> Result<Response> {
 
 pub async fn new_user_submit(
     State(state): State<AuthState>,
-    auth_user: AuthUser,
+    admin_user: AdminUser,
     Form(form): Form<CreateUser>,
 ) -> Result<Response> {
     // Validate input
     if form.username.trim().is_empty() {
         let template = NewUserTemplate {
-            user: auth_user,
+            user: admin_user.0,
             error: Some("Username is required".to_string()),
         };
         return Ok(Html(
@@ -218,7 +219,7 @@ pub async fn new_user_submit(
 
     if form.password.len() < 6 {
         let template = NewUserTemplate {
-            user: auth_user,
+            user: admin_user.0,
             error: Some("Password must be at least 6 characters".to_string()),
         };
         return Ok(Html(
@@ -237,7 +238,7 @@ pub async fn new_user_submit(
         .is_some()
     {
         let template = NewUserTemplate {
-            user: auth_user,
+            user: admin_user.0,
             error: Some("Username already exists".to_string()),
         };
         return Ok(Html(
@@ -248,10 +249,10 @@ pub async fn new_user_submit(
         .into_response());
     }
 
-    // Create user
+    // Create user with regular user role
     state
         .user_repo
-        .create(&form.username, &form.password)
+        .create(&form.username, &form.password, UserRole::User)
         .await?;
 
     Ok(Redirect::to("/users").into_response())
@@ -259,9 +260,11 @@ pub async fn new_user_submit(
 
 pub async fn users_list(State(state): State<AuthState>, auth_user: AuthUser) -> Result<Response> {
     let users = state.user_repo.find_all().await?;
+    let is_admin = auth_user.is_admin();
     let template = UsersListTemplate {
         user: auth_user,
         users,
+        is_admin,
     };
     Ok(Html(
         template
@@ -269,4 +272,34 @@ pub async fn users_list(State(state): State<AuthState>, auth_user: AuthUser) -> 
             .map_err(|e| AppError::Internal(e.to_string()))?,
     )
     .into_response())
+}
+
+pub async fn delete_user(
+    State(state): State<AuthState>,
+    admin_user: AdminUser,
+    Path(user_id): Path<String>,
+) -> Result<Response> {
+    // Prevent self-delete
+    if admin_user.id == user_id {
+        return Err(AppError::BadRequest(
+            "Cannot delete your own account".to_string(),
+        ));
+    }
+
+    state.user_repo.delete(&user_id).await?;
+
+    Ok(Redirect::to("/users").into_response())
+}
+
+pub async fn promote_user(
+    State(state): State<AuthState>,
+    _admin_user: AdminUser,
+    Path(user_id): Path<String>,
+) -> Result<Response> {
+    state
+        .user_repo
+        .update_role(&user_id, UserRole::Admin)
+        .await?;
+
+    Ok(Redirect::to("/users").into_response())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,6 +95,15 @@ fn run_migrations(pool: &DbPool) -> anyhow::Result<()> {
 
     let conn = pool.get()?;
 
+    // Create migrations tracking table if it doesn't exist
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS _migrations (
+            name TEXT PRIMARY KEY,
+            applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )",
+        [],
+    )?;
+
     let migrations_dir = PathBuf::from("migrations");
     let mut entries: Vec<_> = std::fs::read_dir(&migrations_dir)?
         .filter_map(|e| e.ok())
@@ -110,11 +119,29 @@ fn run_migrations(pool: &DbPool) -> anyhow::Result<()> {
 
     for entry in entries {
         let path = entry.path();
-        let filename = path.file_name().unwrap().to_string_lossy();
+        let filename = path.file_name().unwrap().to_string_lossy().to_string();
+
+        // Check if migration was already applied
+        let already_applied: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM _migrations WHERE name = ?",
+                [&filename],
+                |row| row.get(0),
+            )
+            .unwrap_or(false);
+
+        if already_applied {
+            tracing::debug!("Skipping already applied migration: {}", filename);
+            continue;
+        }
+
         tracing::info!("Running migration: {}", filename);
 
         let sql = std::fs::read_to_string(&path)?;
         conn.execute_batch(&sql)?;
+
+        // Record that migration was applied
+        conn.execute("INSERT INTO _migrations (name) VALUES (?)", [&filename])?;
     }
 
     tracing::info!("Migrations completed");

--- a/src/middleware/auth.rs
+++ b/src/middleware/auth.rs
@@ -7,7 +7,7 @@ use axum::{
 };
 use axum_extra::extract::cookie::SignedCookieJar;
 
-use crate::models::User;
+use crate::models::{User, UserRole};
 use crate::session::{
     create_session_cookie, get_session_from_jar, remove_session_cookie, SessionData, SessionKey,
 };
@@ -16,11 +16,12 @@ use crate::session::{
 pub struct AuthUser {
     pub id: String,
     pub username: String,
+    pub role: UserRole,
 }
 
 impl AuthUser {
     pub fn login(jar: SignedCookieJar, user: &User) -> SignedCookieJar {
-        let data = SessionData::new(user.id.clone(), user.username.clone());
+        let data = SessionData::new(user.id.clone(), user.username.clone(), user.role);
         jar.add(create_session_cookie(&data))
     }
 
@@ -32,7 +33,12 @@ impl AuthUser {
         get_session_from_jar(jar).map(|data| Self {
             id: data.user_id,
             username: data.username,
+            role: data.role,
         })
+    }
+
+    pub fn is_admin(&self) -> bool {
+        self.role.is_admin()
     }
 }
 
@@ -80,5 +86,57 @@ where
         let jar = SignedCookieJar::from_headers(&parts.headers, key.0);
 
         Ok(OptionalAuthUser(AuthUser::from_jar(&jar)))
+    }
+}
+
+// Admin user extractor - requires admin role, returns 403 if not admin
+#[derive(Clone, Debug)]
+pub struct AdminUser(pub AuthUser);
+
+impl std::ops::Deref for AdminUser {
+    type Target = AuthUser;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[async_trait]
+impl<S> FromRequestParts<S> for AdminUser
+where
+    S: Send + Sync,
+{
+    type Rejection = AdminOrAuthRedirect;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let Extension(key) = Extension::<SessionKey>::from_request_parts(parts, state)
+            .await
+            .map_err(|_| AdminOrAuthRedirect::Auth)?;
+
+        let jar = SignedCookieJar::from_headers(&parts.headers, key.0);
+
+        let user = AuthUser::from_jar(&jar).ok_or(AdminOrAuthRedirect::Auth)?;
+
+        if user.is_admin() {
+            Ok(AdminUser(user))
+        } else {
+            Err(AdminOrAuthRedirect::Forbidden)
+        }
+    }
+}
+
+pub enum AdminOrAuthRedirect {
+    Auth,
+    Forbidden,
+}
+
+impl IntoResponse for AdminOrAuthRedirect {
+    fn into_response(self) -> Response {
+        match self {
+            AdminOrAuthRedirect::Auth => Redirect::to("/auth/login").into_response(),
+            AdminOrAuthRedirect::Forbidden => {
+                (StatusCode::FORBIDDEN, "Admin access required").into_response()
+            }
+        }
     }
 }

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1,3 +1,3 @@
 pub mod auth;
 
-pub use auth::AuthUser;
+pub use auth::{AdminUser, AuthUser};

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -8,6 +8,6 @@ pub mod workout_session;
 pub use exercise::{CreateExercise, Exercise};
 pub use from_row::FromSqliteRow;
 pub use personal_record::{PersonalRecord, PersonalRecordWithExercise};
-pub use user::{CreateUser, LoginCredentials, User};
+pub use user::{CreateUser, LoginCredentials, User, UserRole};
 pub use workout_log::{CreateWorkoutLog, WorkoutLog, WorkoutLogWithExercise};
 pub use workout_session::{CreateWorkoutSession, WorkoutSession};

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -4,20 +4,51 @@ use serde::{Deserialize, Serialize};
 
 use super::FromSqliteRow;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum UserRole {
+    Admin,
+    #[default]
+    User,
+}
+
+impl UserRole {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            UserRole::Admin => "admin",
+            UserRole::User => "user",
+        }
+    }
+
+    pub fn parse(s: &str) -> Self {
+        match s {
+            "admin" => UserRole::Admin,
+            _ => UserRole::User,
+        }
+    }
+
+    pub fn is_admin(&self) -> bool {
+        matches!(self, UserRole::Admin)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct User {
     pub id: String,
     pub username: String,
     pub password_hash: String,
+    pub role: UserRole,
     pub created_at: DateTime<Utc>,
 }
 
 impl FromSqliteRow for User {
     fn from_row(row: &Row) -> rusqlite::Result<Self> {
+        let role_str: String = row.get("role")?;
         Ok(Self {
             id: row.get("id")?,
             username: row.get("username")?,
             password_hash: row.get("password_hash")?,
+            role: UserRole::parse(&role_str),
             created_at: row.get("created_at")?,
         })
     }

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -65,3 +65,34 @@ pub struct LoginCredentials {
     pub username: String,
     pub password: String,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_user_role_as_str() {
+        assert_eq!(UserRole::Admin.as_str(), "admin");
+        assert_eq!(UserRole::User.as_str(), "user");
+    }
+
+    #[test]
+    fn test_user_role_parse() {
+        assert_eq!(UserRole::parse("admin"), UserRole::Admin);
+        assert_eq!(UserRole::parse("user"), UserRole::User);
+        assert_eq!(UserRole::parse("unknown"), UserRole::User);
+        assert_eq!(UserRole::parse(""), UserRole::User);
+    }
+
+    #[test]
+    fn test_user_role_is_admin() {
+        assert!(UserRole::Admin.is_admin());
+        assert!(!UserRole::User.is_admin());
+    }
+
+    #[test]
+    fn test_user_role_default() {
+        let default_role: UserRole = Default::default();
+        assert_eq!(default_role, UserRole::User);
+    }
+}

--- a/src/repositories/user_repo.rs
+++ b/src/repositories/user_repo.rs
@@ -167,3 +167,216 @@ fn verify_password(password: &str, hash: &str) -> Result<bool> {
         .verify_password(password.as_bytes(), &parsed_hash)
         .is_ok())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::create_memory_pool;
+    use std::path::PathBuf;
+
+    fn setup_test_db() -> DbPool {
+        let pool = create_memory_pool().expect("Failed to create test database");
+        run_migrations(&pool).expect("Failed to run migrations");
+        pool
+    }
+
+    fn run_migrations(pool: &DbPool) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let conn = pool.get()?;
+        let migrations_dir = PathBuf::from("migrations");
+        let mut entries: Vec<_> = std::fs::read_dir(&migrations_dir)?
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.path()
+                    .extension()
+                    .map(|ext| ext == "sql")
+                    .unwrap_or(false)
+            })
+            .collect();
+        entries.sort_by_key(|e| e.file_name());
+        for entry in entries {
+            let path = entry.path();
+            let sql = std::fs::read_to_string(&path)?;
+            conn.execute_batch(&sql)?;
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_count_empty_db() {
+        let pool = setup_test_db();
+        let repo = UserRepository::new(pool);
+
+        let count = repo.count().await.unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_create_user() {
+        let pool = setup_test_db();
+        let repo = UserRepository::new(pool);
+
+        let user = repo.create("testuser", "password123", UserRole::User).await.unwrap();
+
+        assert_eq!(user.username, "testuser");
+        assert_eq!(user.role, UserRole::User);
+        assert!(!user.id.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_create_user_admin_role() {
+        let pool = setup_test_db();
+        let repo = UserRepository::new(pool);
+
+        let user = repo.create("admin", "adminpass", UserRole::Admin).await.unwrap();
+
+        assert_eq!(user.username, "admin");
+        assert_eq!(user.role, UserRole::Admin);
+    }
+
+    #[tokio::test]
+    async fn test_find_by_id_exists() {
+        let pool = setup_test_db();
+        let repo = UserRepository::new(pool);
+
+        let created = repo.create("testuser", "password", UserRole::User).await.unwrap();
+        let found = repo.find_by_id(&created.id).await.unwrap();
+
+        assert!(found.is_some());
+        let user = found.unwrap();
+        assert_eq!(user.id, created.id);
+        assert_eq!(user.username, "testuser");
+    }
+
+    #[tokio::test]
+    async fn test_find_by_id_not_exists() {
+        let pool = setup_test_db();
+        let repo = UserRepository::new(pool);
+
+        let found = repo.find_by_id("nonexistent-id").await.unwrap();
+
+        assert!(found.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_find_by_username_exists() {
+        let pool = setup_test_db();
+        let repo = UserRepository::new(pool);
+
+        repo.create("findme", "password", UserRole::User).await.unwrap();
+        let found = repo.find_by_username("findme").await.unwrap();
+
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().username, "findme");
+    }
+
+    #[tokio::test]
+    async fn test_find_by_username_not_exists() {
+        let pool = setup_test_db();
+        let repo = UserRepository::new(pool);
+
+        let found = repo.find_by_username("nouser").await.unwrap();
+
+        assert!(found.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_find_all_multiple() {
+        let pool = setup_test_db();
+        let repo = UserRepository::new(pool);
+
+        repo.create("user1", "pass1", UserRole::User).await.unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        repo.create("user2", "pass2", UserRole::Admin).await.unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        repo.create("user3", "pass3", UserRole::User).await.unwrap();
+
+        let users = repo.find_all().await.unwrap();
+
+        assert_eq!(users.len(), 3);
+        // Should be ordered by created_at DESC
+        assert_eq!(users[0].username, "user3");
+        assert_eq!(users[1].username, "user2");
+        assert_eq!(users[2].username, "user1");
+    }
+
+    #[tokio::test]
+    async fn test_verify_password_correct() {
+        let pool = setup_test_db();
+        let repo = UserRepository::new(pool);
+
+        repo.create("verifyuser", "correctpass", UserRole::User).await.unwrap();
+        let result = repo.verify_password("verifyuser", "correctpass").await.unwrap();
+
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().username, "verifyuser");
+    }
+
+    #[tokio::test]
+    async fn test_verify_password_incorrect() {
+        let pool = setup_test_db();
+        let repo = UserRepository::new(pool);
+
+        repo.create("verifyuser2", "correctpass", UserRole::User).await.unwrap();
+        let result = repo.verify_password("verifyuser2", "wrongpass").await.unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_verify_password_user_not_exists() {
+        let pool = setup_test_db();
+        let repo = UserRepository::new(pool);
+
+        let result = repo.verify_password("nouser", "anypass").await.unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_delete_user_exists() {
+        let pool = setup_test_db();
+        let repo = UserRepository::new(pool);
+
+        let user = repo.create("deleteuser", "pass", UserRole::User).await.unwrap();
+        let deleted = repo.delete(&user.id).await.unwrap();
+
+        assert!(deleted);
+        let found = repo.find_by_id(&user.id).await.unwrap();
+        assert!(found.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_delete_user_not_exists() {
+        let pool = setup_test_db();
+        let repo = UserRepository::new(pool);
+
+        let deleted = repo.delete("nonexistent-id").await.unwrap();
+
+        assert!(!deleted);
+    }
+
+    #[tokio::test]
+    async fn test_update_role_success() {
+        let pool = setup_test_db();
+        let repo = UserRepository::new(pool);
+
+        let user = repo.create("roleuser", "pass", UserRole::User).await.unwrap();
+        assert_eq!(user.role, UserRole::User);
+
+        let updated = repo.update_role(&user.id, UserRole::Admin).await.unwrap();
+        assert!(updated);
+
+        let found = repo.find_by_id(&user.id).await.unwrap().unwrap();
+        assert_eq!(found.role, UserRole::Admin);
+    }
+
+    #[tokio::test]
+    async fn test_update_role_not_exists() {
+        let pool = setup_test_db();
+        let repo = UserRepository::new(pool);
+
+        let updated = repo.update_role("nonexistent", UserRole::Admin).await.unwrap();
+
+        assert!(!updated);
+    }
+}

--- a/src/repositories/user_repo.rs
+++ b/src/repositories/user_repo.rs
@@ -215,7 +215,10 @@ mod tests {
         let pool = setup_test_db();
         let repo = UserRepository::new(pool);
 
-        let user = repo.create("testuser", "password123", UserRole::User).await.unwrap();
+        let user = repo
+            .create("testuser", "password123", UserRole::User)
+            .await
+            .unwrap();
 
         assert_eq!(user.username, "testuser");
         assert_eq!(user.role, UserRole::User);
@@ -227,7 +230,10 @@ mod tests {
         let pool = setup_test_db();
         let repo = UserRepository::new(pool);
 
-        let user = repo.create("admin", "adminpass", UserRole::Admin).await.unwrap();
+        let user = repo
+            .create("admin", "adminpass", UserRole::Admin)
+            .await
+            .unwrap();
 
         assert_eq!(user.username, "admin");
         assert_eq!(user.role, UserRole::Admin);
@@ -238,7 +244,10 @@ mod tests {
         let pool = setup_test_db();
         let repo = UserRepository::new(pool);
 
-        let created = repo.create("testuser", "password", UserRole::User).await.unwrap();
+        let created = repo
+            .create("testuser", "password", UserRole::User)
+            .await
+            .unwrap();
         let found = repo.find_by_id(&created.id).await.unwrap();
 
         assert!(found.is_some());
@@ -262,7 +271,9 @@ mod tests {
         let pool = setup_test_db();
         let repo = UserRepository::new(pool);
 
-        repo.create("findme", "password", UserRole::User).await.unwrap();
+        repo.create("findme", "password", UserRole::User)
+            .await
+            .unwrap();
         let found = repo.find_by_username("findme").await.unwrap();
 
         assert!(found.is_some());
@@ -286,7 +297,9 @@ mod tests {
 
         repo.create("user1", "pass1", UserRole::User).await.unwrap();
         tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
-        repo.create("user2", "pass2", UserRole::Admin).await.unwrap();
+        repo.create("user2", "pass2", UserRole::Admin)
+            .await
+            .unwrap();
         tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
         repo.create("user3", "pass3", UserRole::User).await.unwrap();
 
@@ -304,8 +317,13 @@ mod tests {
         let pool = setup_test_db();
         let repo = UserRepository::new(pool);
 
-        repo.create("verifyuser", "correctpass", UserRole::User).await.unwrap();
-        let result = repo.verify_password("verifyuser", "correctpass").await.unwrap();
+        repo.create("verifyuser", "correctpass", UserRole::User)
+            .await
+            .unwrap();
+        let result = repo
+            .verify_password("verifyuser", "correctpass")
+            .await
+            .unwrap();
 
         assert!(result.is_some());
         assert_eq!(result.unwrap().username, "verifyuser");
@@ -316,8 +334,13 @@ mod tests {
         let pool = setup_test_db();
         let repo = UserRepository::new(pool);
 
-        repo.create("verifyuser2", "correctpass", UserRole::User).await.unwrap();
-        let result = repo.verify_password("verifyuser2", "wrongpass").await.unwrap();
+        repo.create("verifyuser2", "correctpass", UserRole::User)
+            .await
+            .unwrap();
+        let result = repo
+            .verify_password("verifyuser2", "wrongpass")
+            .await
+            .unwrap();
 
         assert!(result.is_none());
     }
@@ -337,7 +360,10 @@ mod tests {
         let pool = setup_test_db();
         let repo = UserRepository::new(pool);
 
-        let user = repo.create("deleteuser", "pass", UserRole::User).await.unwrap();
+        let user = repo
+            .create("deleteuser", "pass", UserRole::User)
+            .await
+            .unwrap();
         let deleted = repo.delete(&user.id).await.unwrap();
 
         assert!(deleted);
@@ -360,7 +386,10 @@ mod tests {
         let pool = setup_test_db();
         let repo = UserRepository::new(pool);
 
-        let user = repo.create("roleuser", "pass", UserRole::User).await.unwrap();
+        let user = repo
+            .create("roleuser", "pass", UserRole::User)
+            .await
+            .unwrap();
         assert_eq!(user.role, UserRole::User);
 
         let updated = repo.update_role(&user.id, UserRole::Admin).await.unwrap();
@@ -375,7 +404,10 @@ mod tests {
         let pool = setup_test_db();
         let repo = UserRepository::new(pool);
 
-        let updated = repo.update_role("nonexistent", UserRole::Admin).await.unwrap();
+        let updated = repo
+            .update_role("nonexistent", UserRole::Admin)
+            .await
+            .unwrap();
 
         assert!(!updated);
     }

--- a/src/repositories/workout_repo.rs
+++ b/src/repositories/workout_repo.rs
@@ -569,7 +569,10 @@ mod tests {
         let repo = WorkoutRepository::new(pool);
 
         let date = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
-        let session = repo.create_session("user1", date, Some("Leg day")).await.unwrap();
+        let session = repo
+            .create_session("user1", date, Some("Leg day"))
+            .await
+            .unwrap();
 
         assert_eq!(session.user_id, "user1");
         assert_eq!(session.date, date);

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -33,6 +33,8 @@ pub fn create_router(
             "/users/new",
             get(auth::new_user_page).post(auth::new_user_submit),
         )
+        .route("/users/:id/delete", post(auth::delete_user))
+        .route("/users/:id/promote", post(auth::promote_user))
         .with_state(auth_state)
         // Workout routes
         .route("/workouts", get(workouts::list))

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,6 +1,8 @@
 use axum_extra::extract::cookie::{Cookie, Key, SignedCookieJar};
 use serde::{Deserialize, Serialize};
 
+use crate::models::UserRole;
+
 pub const SESSION_COOKIE_NAME: &str = "session";
 
 #[derive(Clone)]
@@ -21,11 +23,21 @@ impl SessionKey {
 pub struct SessionData {
     pub user_id: String,
     pub username: String,
+    pub role: UserRole,
 }
 
 impl SessionData {
-    pub fn new(user_id: String, username: String) -> Self {
-        Self { user_id, username }
+    pub fn new(user_id: String, username: String, role: UserRole) -> Self {
+        Self {
+            user_id,
+            username,
+            role,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn is_admin(&self) -> bool {
+        self.role.is_admin()
     }
 
     pub fn to_cookie_value(&self) -> String {

--- a/templates/auth/users.html
+++ b/templates/auth/users.html
@@ -7,20 +7,43 @@
 
 <h1>Users</h1>
 
+{% if is_admin %}
 <p><a href="/users/new">[+ Add New User]</a></p>
+{% endif %}
 
 <table>
     <thead>
         <tr>
             <th>Username</th>
+            <th>Role</th>
             <th>Created</th>
+            {% if is_admin %}
+            <th>Actions</th>
+            {% endif %}
         </tr>
     </thead>
     <tbody>
         {% for u in users %}
         <tr>
             <td>{{ u.username }}</td>
+            <td>{{ u.role.as_str() }}</td>
             <td class="muted">{{ u.created_at.format("%Y-%m-%d %H:%M") }}</td>
+            {% if is_admin %}
+            <td>
+                {% if u.id != user.id %}
+                    {% if !u.role.is_admin() %}
+                    <form action="/users/{{ u.id }}/promote" method="post" style="display:inline;" onsubmit="return confirm('Promote {{ u.username }} to admin?');">
+                        <button type="submit">[Promote]</button>
+                    </form>
+                    {% endif %}
+                    <form action="/users/{{ u.id }}/delete" method="post" style="display:inline;" onsubmit="return confirm('Delete user {{ u.username }}?');">
+                        <button type="submit" class="btn-danger">[Delete]</button>
+                    </form>
+                {% else %}
+                <span class="muted">(you)</span>
+                {% endif %}
+            </td>
+            {% endif %}
         </tr>
         {% endfor %}
     </tbody>

--- a/templates/nav.html
+++ b/templates/nav.html
@@ -6,7 +6,7 @@
         <li><a href="/stats">[Stats]</a></li>
         <li><a href="/users">[Users]</a></li>
         <li class="ml-auto">
-            <span class="muted">{{ user.username }}</span>
+            <span class="muted">{{ user.username }}{% if user.is_admin() %} <strong>[admin]</strong>{% endif %}</span>
             <form action="/auth/logout" method="post" style="display:inline;">
                 <button type="submit" style="background:none;color:#111;border:none;padding:0;cursor:pointer;">[Sign Out]</button>
             </form>

--- a/tests/auth_test.rs
+++ b/tests/auth_test.rs
@@ -2,8 +2,10 @@ mod common;
 
 use axum::{
     body::Body,
-    http::{Request, StatusCode},
+    http::{header, Request, StatusCode},
 };
+use http_body_util::BodyExt;
+use liftlog::models::UserRole;
 use tower::ServiceExt;
 
 #[tokio::test]
@@ -54,6 +56,183 @@ async fn test_dashboard_requires_auth() {
         .unwrap();
 
     // Should redirect to login
+    assert_eq!(response.status(), StatusCode::SEE_OTHER);
+    assert_eq!(response.headers().get("location").unwrap(), "/auth/login");
+}
+
+#[tokio::test]
+async fn test_login_valid_credentials() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_key(pool.clone());
+
+    // Create a test user
+    common::create_test_user(&pool, "testuser", "password123", UserRole::User).await;
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/auth/login")
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .body(Body::from("username=testuser&password=password123"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Should redirect to dashboard on success
+    assert_eq!(response.status(), StatusCode::SEE_OTHER);
+    assert_eq!(response.headers().get("location").unwrap(), "/");
+
+    // Should set a session cookie
+    let set_cookie = response.headers().get(header::SET_COOKIE);
+    assert!(set_cookie.is_some());
+    let cookie_str = set_cookie.unwrap().to_str().unwrap();
+    assert!(cookie_str.contains("session="));
+}
+
+#[tokio::test]
+async fn test_login_invalid_credentials() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_key(pool.clone());
+
+    // Create a test user
+    common::create_test_user(&pool, "testuser", "password123", UserRole::User).await;
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/auth/login")
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .body(Body::from("username=testuser&password=wrongpassword"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Should return OK with error message (not redirect)
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_str = String::from_utf8_lossy(&body);
+    assert!(body_str.contains("Invalid username or password"));
+}
+
+#[tokio::test]
+async fn test_login_nonexistent_user() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_key(pool.clone());
+
+    // Create a user so we don't get redirected to setup
+    common::create_test_user(&pool, "existing", "password", UserRole::User).await;
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/auth/login")
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .body(Body::from("username=nonexistent&password=anypassword"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_str = String::from_utf8_lossy(&body);
+    assert!(body_str.contains("Invalid username or password"));
+}
+
+#[tokio::test]
+async fn test_logout_clears_session() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_key(pool.clone());
+
+    // Create and login a user
+    let user = common::create_test_user(&pool, "testuser", "password123", UserRole::User).await;
+    let session_cookie = common::create_session_cookie(&user, &test_app.session_key);
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/auth/logout")
+                .header(header::COOKIE, &cookie_header)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Should redirect to login
+    assert_eq!(response.status(), StatusCode::SEE_OTHER);
+    assert_eq!(response.headers().get("location").unwrap(), "/auth/login");
+
+    // Should clear the session cookie (max-age=0 or empty value)
+    let set_cookie = response.headers().get(header::SET_COOKIE);
+    assert!(set_cookie.is_some());
+    let cookie_str = set_cookie.unwrap().to_str().unwrap();
+    // Cookie should be cleared (either empty or max-age=0)
+    assert!(cookie_str.contains("Max-Age=0") || cookie_str.contains("session=;"));
+}
+
+#[tokio::test]
+async fn test_setup_creates_admin_user() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_key(pool.clone());
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/auth/setup")
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .body(Body::from("username=admin&password=adminpass123"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Should redirect to dashboard after successful setup
+    assert_eq!(response.status(), StatusCode::SEE_OTHER);
+    assert_eq!(response.headers().get("location").unwrap(), "/");
+
+    // Verify user was created with admin role
+    let user_repo = liftlog::repositories::UserRepository::new(pool);
+    let user = user_repo.find_by_username("admin").await.unwrap();
+    assert!(user.is_some());
+    assert_eq!(user.unwrap().role, UserRole::Admin);
+}
+
+#[tokio::test]
+async fn test_setup_redirects_when_users_exist() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_key(pool.clone());
+
+    // Create an existing user
+    common::create_test_user(&pool, "existing", "password", UserRole::User).await;
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .uri("/auth/setup")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Should redirect to login when users already exist
     assert_eq!(response.status(), StatusCode::SEE_OTHER);
     assert_eq!(response.headers().get("location").unwrap(), "/auth/login");
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -95,7 +95,12 @@ pub fn create_test_app_with_key(pool: DbPool) -> TestApp {
     }
 }
 
-pub async fn create_test_user(pool: &DbPool, username: &str, password: &str, role: UserRole) -> User {
+pub async fn create_test_user(
+    pool: &DbPool,
+    username: &str,
+    password: &str,
+    role: UserRole,
+) -> User {
     let user_repo = UserRepository::new(pool.clone());
     user_repo.create(username, password, role).await.unwrap()
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,6 +2,8 @@ use axum::Router;
 use std::path::PathBuf;
 
 use liftlog::db::{create_memory_pool, DbPool};
+use liftlog::models::{User, UserRole};
+use liftlog::repositories::UserRepository;
 use liftlog::session::SessionKey;
 
 pub fn setup_test_db() -> DbPool {
@@ -38,9 +40,18 @@ fn run_migrations(pool: &DbPool) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+pub struct TestApp {
+    pub router: Router,
+    pub session_key: SessionKey,
+}
+
 pub fn create_test_app(pool: DbPool) -> Router {
+    create_test_app_with_key(pool).router
+}
+
+pub fn create_test_app_with_key(pool: DbPool) -> TestApp {
     use liftlog::handlers::{auth, dashboard, exercises, stats, workouts};
-    use liftlog::repositories::{ExerciseRepository, UserRepository, WorkoutRepository};
+    use liftlog::repositories::{ExerciseRepository, WorkoutRepository};
 
     // Generate session key for tests
     let session_key = SessionKey::generate();
@@ -69,12 +80,47 @@ pub fn create_test_app(pool: DbPool) -> Router {
         exercise_repo: exercise_repo.clone(),
     };
 
-    liftlog::routes::create_router(
+    let router = liftlog::routes::create_router(
         auth_state,
         dashboard_state,
         workouts_state,
         exercises_state,
         stats_state,
+        session_key.clone(),
+    );
+
+    TestApp {
+        router,
         session_key,
-    )
+    }
+}
+
+pub async fn create_test_user(pool: &DbPool, username: &str, password: &str, role: UserRole) -> User {
+    let user_repo = UserRepository::new(pool.clone());
+    user_repo.create(username, password, role).await.unwrap()
+}
+
+pub fn create_session_cookie(user: &User, session_key: &SessionKey) -> String {
+    use axum::http::HeaderMap;
+    use axum_extra::extract::cookie::SignedCookieJar;
+    use liftlog::middleware::AuthUser;
+
+    let jar = SignedCookieJar::from_headers(&HeaderMap::new(), session_key.0.clone());
+    let jar = AuthUser::login(jar, user);
+
+    // Extract the cookie from the jar using into_response
+    use axum::response::IntoResponse;
+    let response = jar.into_response();
+    let headers = response.headers();
+
+    headers
+        .get(axum::http::header::SET_COOKIE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string()
+}
+
+pub fn extract_cookie_header(set_cookie: &str) -> String {
+    // Extract just the cookie name=value part for use in Cookie header
+    set_cookie.split(';').next().unwrap_or("").to_string()
 }

--- a/tests/role_permissions_test.rs
+++ b/tests/role_permissions_test.rs
@@ -1,0 +1,384 @@
+mod common;
+
+use axum::{
+    body::Body,
+    http::{header, Request, StatusCode},
+};
+use http_body_util::BodyExt;
+use liftlog::models::UserRole;
+use liftlog::repositories::UserRepository;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn test_admin_can_access_users_page() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_key(pool.clone());
+
+    // Create an admin user
+    let admin = common::create_test_user(&pool, "admin", "adminpass", UserRole::Admin).await;
+    let session_cookie = common::create_session_cookie(&admin, &test_app.session_key);
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .uri("/users")
+                .header(header::COOKIE, &cookie_header)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_str = String::from_utf8_lossy(&body);
+
+    // Should show the users list with the admin user
+    assert!(body_str.contains("admin"));
+}
+
+#[tokio::test]
+async fn test_user_can_access_users_page() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_key(pool.clone());
+
+    // Create a regular user
+    let user = common::create_test_user(&pool, "regularuser", "password", UserRole::User).await;
+    let session_cookie = common::create_session_cookie(&user, &test_app.session_key);
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .uri("/users")
+                .header(header::COOKIE, &cookie_header)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Users list is accessible to all logged in users (they can see the list)
+    // but admin-only actions are restricted
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_user_cannot_access_new_user_page() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_key(pool.clone());
+
+    // Create a regular user
+    let user = common::create_test_user(&pool, "regularuser", "password", UserRole::User).await;
+    let session_cookie = common::create_session_cookie(&user, &test_app.session_key);
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .uri("/users/new")
+                .header(header::COOKIE, &cookie_header)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Regular users should get 403 Forbidden
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn test_admin_can_access_new_user_page() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_key(pool.clone());
+
+    // Create an admin user
+    let admin = common::create_test_user(&pool, "admin", "adminpass", UserRole::Admin).await;
+    let session_cookie = common::create_session_cookie(&admin, &test_app.session_key);
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .uri("/users/new")
+                .header(header::COOKIE, &cookie_header)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_admin_can_delete_user() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_key(pool.clone());
+
+    // Create an admin and a regular user
+    let admin = common::create_test_user(&pool, "admin", "adminpass", UserRole::Admin).await;
+    let user = common::create_test_user(&pool, "regularuser", "password", UserRole::User).await;
+
+    let session_cookie = common::create_session_cookie(&admin, &test_app.session_key);
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(&format!("/users/{}/delete", user.id))
+                .header(header::COOKIE, &cookie_header)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Should redirect to users list
+    assert_eq!(response.status(), StatusCode::SEE_OTHER);
+    assert_eq!(response.headers().get("location").unwrap(), "/users");
+
+    // Verify user was deleted
+    let user_repo = UserRepository::new(pool);
+    let found = user_repo.find_by_id(&user.id).await.unwrap();
+    assert!(found.is_none());
+}
+
+#[tokio::test]
+async fn test_user_cannot_delete_user() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_key(pool.clone());
+
+    // Create two regular users
+    let user1 = common::create_test_user(&pool, "user1", "password", UserRole::User).await;
+    let user2 = common::create_test_user(&pool, "user2", "password", UserRole::User).await;
+
+    let session_cookie = common::create_session_cookie(&user1, &test_app.session_key);
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(&format!("/users/{}/delete", user2.id))
+                .header(header::COOKIE, &cookie_header)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Should get 403 Forbidden
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+    // User should still exist
+    let user_repo = UserRepository::new(pool);
+    let found = user_repo.find_by_id(&user2.id).await.unwrap();
+    assert!(found.is_some());
+}
+
+#[tokio::test]
+async fn test_admin_cannot_self_delete() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_key(pool.clone());
+
+    // Create an admin
+    let admin = common::create_test_user(&pool, "admin", "adminpass", UserRole::Admin).await;
+
+    let session_cookie = common::create_session_cookie(&admin, &test_app.session_key);
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(&format!("/users/{}/delete", admin.id))
+                .header(header::COOKIE, &cookie_header)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Should get 400 Bad Request (cannot delete yourself)
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    // Admin should still exist
+    let user_repo = UserRepository::new(pool);
+    let found = user_repo.find_by_id(&admin.id).await.unwrap();
+    assert!(found.is_some());
+}
+
+#[tokio::test]
+async fn test_admin_can_promote_user() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_key(pool.clone());
+
+    // Create an admin and a regular user
+    let admin = common::create_test_user(&pool, "admin", "adminpass", UserRole::Admin).await;
+    let user = common::create_test_user(&pool, "regularuser", "password", UserRole::User).await;
+
+    let session_cookie = common::create_session_cookie(&admin, &test_app.session_key);
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(&format!("/users/{}/promote", user.id))
+                .header(header::COOKIE, &cookie_header)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Should redirect to users list
+    assert_eq!(response.status(), StatusCode::SEE_OTHER);
+    assert_eq!(response.headers().get("location").unwrap(), "/users");
+
+    // Verify user was promoted to admin
+    let user_repo = UserRepository::new(pool);
+    let found = user_repo.find_by_id(&user.id).await.unwrap().unwrap();
+    assert_eq!(found.role, UserRole::Admin);
+}
+
+#[tokio::test]
+async fn test_user_cannot_promote_user() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_key(pool.clone());
+
+    // Create two regular users
+    let user1 = common::create_test_user(&pool, "user1", "password", UserRole::User).await;
+    let user2 = common::create_test_user(&pool, "user2", "password", UserRole::User).await;
+
+    let session_cookie = common::create_session_cookie(&user1, &test_app.session_key);
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(&format!("/users/{}/promote", user2.id))
+                .header(header::COOKIE, &cookie_header)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Should get 403 Forbidden
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+    // User2 should still be a regular user
+    let user_repo = UserRepository::new(pool);
+    let found = user_repo.find_by_id(&user2.id).await.unwrap().unwrap();
+    assert_eq!(found.role, UserRole::User);
+}
+
+#[tokio::test]
+async fn test_admin_can_create_new_user() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_key(pool.clone());
+
+    // Create an admin
+    let admin = common::create_test_user(&pool, "admin", "adminpass", UserRole::Admin).await;
+
+    let session_cookie = common::create_session_cookie(&admin, &test_app.session_key);
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/users/new")
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .header(header::COOKIE, &cookie_header)
+                .body(Body::from("username=newuser&password=password123"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Should redirect to users list
+    assert_eq!(response.status(), StatusCode::SEE_OTHER);
+    assert_eq!(response.headers().get("location").unwrap(), "/users");
+
+    // Verify new user was created
+    let user_repo = UserRepository::new(pool);
+    let found = user_repo.find_by_username("newuser").await.unwrap();
+    assert!(found.is_some());
+    assert_eq!(found.unwrap().role, UserRole::User);
+}
+
+#[tokio::test]
+async fn test_user_cannot_create_new_user() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_key(pool.clone());
+
+    // Create a regular user
+    let user = common::create_test_user(&pool, "regularuser", "password", UserRole::User).await;
+
+    let session_cookie = common::create_session_cookie(&user, &test_app.session_key);
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/users/new")
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .header(header::COOKIE, &cookie_header)
+                .body(Body::from("username=newuser&password=password123"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Should get 403 Forbidden
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+    // User should not be created
+    let user_repo = UserRepository::new(pool);
+    let found = user_repo.find_by_username("newuser").await.unwrap();
+    assert!(found.is_none());
+}
+
+#[tokio::test]
+async fn test_unauthenticated_cannot_access_users() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_key(pool.clone());
+
+    // Create a user so the app doesn't redirect to setup
+    common::create_test_user(&pool, "existing", "password", UserRole::User).await;
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .uri("/users")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Should redirect to login
+    assert_eq!(response.status(), StatusCode::SEE_OTHER);
+    assert_eq!(response.headers().get("location").unwrap(), "/auth/login");
+}

--- a/tests/workout_test.rs
+++ b/tests/workout_test.rs
@@ -2,8 +2,11 @@ mod common;
 
 use axum::{
     body::Body,
-    http::{Request, StatusCode},
+    http::{header, Request, StatusCode},
 };
+use http_body_util::BodyExt;
+use liftlog::models::UserRole;
+use liftlog::repositories::WorkoutRepository;
 use tower::ServiceExt;
 
 #[tokio::test]
@@ -43,4 +46,311 @@ async fn test_new_workout_requires_auth() {
 
     // Should redirect to login
     assert_eq!(response.status(), StatusCode::SEE_OTHER);
+}
+
+#[tokio::test]
+async fn test_create_workout_authenticated() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_key(pool.clone());
+
+    // Create a test user
+    let user = common::create_test_user(&pool, "testuser", "password123", UserRole::User).await;
+    let session_cookie = common::create_session_cookie(&user, &test_app.session_key);
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/workouts")
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .header(header::COOKIE, &cookie_header)
+                .body(Body::from("date=2024-01-15&notes=Leg%20day"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Should redirect to the workout page
+    assert_eq!(response.status(), StatusCode::SEE_OTHER);
+    let location = response.headers().get("location").unwrap().to_str().unwrap();
+    assert!(location.starts_with("/workouts/"));
+
+    // Verify workout was created in database
+    let workout_repo = WorkoutRepository::new(pool);
+    let count = workout_repo.count_sessions_by_user(&user.id).await.unwrap();
+    assert_eq!(count, 1);
+}
+
+#[tokio::test]
+async fn test_workout_list_shows_user_workouts() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_key(pool.clone());
+
+    // Create a test user and some workouts
+    let user = common::create_test_user(&pool, "testuser", "password123", UserRole::User).await;
+    let session_cookie = common::create_session_cookie(&user, &test_app.session_key);
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    // Create workouts directly via repository
+    let workout_repo = WorkoutRepository::new(pool.clone());
+    workout_repo
+        .create_session(
+            &user.id,
+            chrono::NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
+            Some("Chest day"),
+        )
+        .await
+        .unwrap();
+    workout_repo
+        .create_session(
+            &user.id,
+            chrono::NaiveDate::from_ymd_opt(2024, 1, 16).unwrap(),
+            Some("Back day"),
+        )
+        .await
+        .unwrap();
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .uri("/workouts")
+                .header(header::COOKIE, &cookie_header)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_str = String::from_utf8_lossy(&body);
+
+    // Verify workouts are shown
+    assert!(body_str.contains("Chest day") || body_str.contains("2024-01-15"));
+    assert!(body_str.contains("Back day") || body_str.contains("2024-01-16"));
+}
+
+#[tokio::test]
+async fn test_workout_list_only_shows_own_workouts() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_key(pool.clone());
+
+    // Create two users
+    let user1 = common::create_test_user(&pool, "user1", "password123", UserRole::User).await;
+    let user2 = common::create_test_user(&pool, "user2", "password456", UserRole::User).await;
+
+    // Create workouts for both users
+    let workout_repo = WorkoutRepository::new(pool.clone());
+    workout_repo
+        .create_session(
+            &user1.id,
+            chrono::NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
+            Some("User1 workout"),
+        )
+        .await
+        .unwrap();
+    workout_repo
+        .create_session(
+            &user2.id,
+            chrono::NaiveDate::from_ymd_opt(2024, 1, 16).unwrap(),
+            Some("User2 workout"),
+        )
+        .await
+        .unwrap();
+
+    // Login as user1
+    let session_cookie = common::create_session_cookie(&user1, &test_app.session_key);
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .uri("/workouts")
+                .header(header::COOKIE, &cookie_header)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_str = String::from_utf8_lossy(&body);
+
+    // User1 should see their workout but not User2's
+    assert!(body_str.contains("User1 workout") || body_str.contains("2024-01-15"));
+    assert!(!body_str.contains("User2 workout"));
+}
+
+#[tokio::test]
+async fn test_delete_workout() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_key(pool.clone());
+
+    // Create a test user and a workout
+    let user = common::create_test_user(&pool, "testuser", "password123", UserRole::User).await;
+    let session_cookie = common::create_session_cookie(&user, &test_app.session_key);
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    let workout_repo = WorkoutRepository::new(pool.clone());
+    let workout = workout_repo
+        .create_session(
+            &user.id,
+            chrono::NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(&format!("/workouts/{}/delete", workout.id))
+                .header(header::COOKIE, &cookie_header)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Should redirect to workouts list
+    assert_eq!(response.status(), StatusCode::SEE_OTHER);
+    assert_eq!(response.headers().get("location").unwrap(), "/workouts");
+
+    // Verify workout was deleted
+    let count = workout_repo.count_sessions_by_user(&user.id).await.unwrap();
+    assert_eq!(count, 0);
+}
+
+#[tokio::test]
+async fn test_cannot_delete_others_workout() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_key(pool.clone());
+
+    // Create two users
+    let user1 = common::create_test_user(&pool, "user1", "password123", UserRole::User).await;
+    let user2 = common::create_test_user(&pool, "user2", "password456", UserRole::User).await;
+
+    // Create a workout for user2
+    let workout_repo = WorkoutRepository::new(pool.clone());
+    let workout = workout_repo
+        .create_session(
+            &user2.id,
+            chrono::NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Login as user1 and try to delete user2's workout
+    let session_cookie = common::create_session_cookie(&user1, &test_app.session_key);
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(&format!("/workouts/{}/delete", workout.id))
+                .header(header::COOKIE, &cookie_header)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Should still redirect (delete returns success even if no rows affected)
+    assert_eq!(response.status(), StatusCode::SEE_OTHER);
+
+    // But the workout should still exist
+    let found = workout_repo.find_session_by_id(&workout.id).await.unwrap();
+    assert!(found.is_some());
+}
+
+#[tokio::test]
+async fn test_view_workout_details() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_key(pool.clone());
+
+    // Create a test user and a workout
+    let user = common::create_test_user(&pool, "testuser", "password123", UserRole::User).await;
+    let session_cookie = common::create_session_cookie(&user, &test_app.session_key);
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    let workout_repo = WorkoutRepository::new(pool.clone());
+    let workout = workout_repo
+        .create_session(
+            &user.id,
+            chrono::NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
+            Some("Test workout"),
+        )
+        .await
+        .unwrap();
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .uri(&format!("/workouts/{}", workout.id))
+                .header(header::COOKIE, &cookie_header)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_str = String::from_utf8_lossy(&body);
+
+    assert!(body_str.contains("2024-01-15") || body_str.contains("Test workout"));
+}
+
+#[tokio::test]
+async fn test_cannot_view_others_workout() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_key(pool.clone());
+
+    // Create two users
+    let user1 = common::create_test_user(&pool, "user1", "password123", UserRole::User).await;
+    let user2 = common::create_test_user(&pool, "user2", "password456", UserRole::User).await;
+
+    // Create a workout for user2
+    let workout_repo = WorkoutRepository::new(pool.clone());
+    let workout = workout_repo
+        .create_session(
+            &user2.id,
+            chrono::NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Login as user1 and try to view user2's workout
+    let session_cookie = common::create_session_cookie(&user1, &test_app.session_key);
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .uri(&format!("/workouts/{}", workout.id))
+                .header(header::COOKIE, &cookie_header)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Should return 404 (not found - for security we don't reveal existence)
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }

--- a/tests/workout_test.rs
+++ b/tests/workout_test.rs
@@ -74,7 +74,12 @@ async fn test_create_workout_authenticated() {
 
     // Should redirect to the workout page
     assert_eq!(response.status(), StatusCode::SEE_OTHER);
-    let location = response.headers().get("location").unwrap().to_str().unwrap();
+    let location = response
+        .headers()
+        .get("location")
+        .unwrap()
+        .to_str()
+        .unwrap();
     assert!(location.starts_with("/workouts/"));
 
     // Verify workout was created in database


### PR DESCRIPTION
## Summary
- Add `UserRole` enum (Admin/User) with role-based access control
- First user created via `/auth/setup` is automatically admin
- Only admins can add new users, delete users, and promote users to admin
- Add `AdminUser` extractor for protected admin-only routes
- Add migration tracking system to prevent duplicate migrations
- Show admin badge in nav and role column in users list

## Changes
- **Database**: New migration `007_add_user_role.sql` adds `role` column
- **Models**: `UserRole` enum with `Admin`/`User` variants
- **Middleware**: `AdminUser` extractor returns 403 for non-admins
- **Handlers**: Role checks on user management endpoints
- **Templates**: Conditional UI for admin-only actions

## Test plan
- [x] Delete database and run fresh setup - first user should be admin
- [x] Admin can access `/users/new` and create new users
- [x] Admin can delete other users but not self
- [x] Admin can promote regular users to admin
- [x] Non-admin users get 403 on admin-only endpoints
- [x] Non-admin users don't see admin UI elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)