### PR TITLE
feat: add multi-architecture support in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Stage 1: Chef - prepare recipe
-FROM rust:1-bookworm AS chef
+# Stage 1: Chef - prepare recipe (runs on build platform)
+FROM --platform=$BUILDPLATFORM rust:1.92-bookworm AS chef
 RUN cargo install cargo-chef
 WORKDIR /app
 
@@ -8,17 +8,57 @@ FROM chef AS planner
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
-# Stage 3: Builder - build dependencies then app
+# Stage 3: Builder - cross-compile for target platform
 FROM chef AS builder
+
+# Target platform args (set by docker buildx)
+ARG TARGETPLATFORM
+ARG GIT_VERSION=dev
+
+# Install cross-compilation toolchain based on target
+RUN case "$TARGETPLATFORM" in \
+        "linux/arm64") \
+            apt-get update && apt-get install -y gcc-aarch64-linux-gnu && \
+            rustup target add aarch64-unknown-linux-gnu \
+            ;; \
+        "linux/amd64") \
+            # Native build, no extra toolchain needed \
+            ;; \
+    esac
+
+# Configure cargo for cross-compilation
+RUN mkdir -p .cargo && \
+    case "$TARGETPLATFORM" in \
+        "linux/arm64") \
+            echo '[target.aarch64-unknown-linux-gnu]' >> .cargo/config.toml && \
+            echo 'linker = "aarch64-linux-gnu-gcc"' >> .cargo/config.toml \
+            ;; \
+    esac
+
+# Set the Rust target based on platform
+RUN case "$TARGETPLATFORM" in \
+        "linux/arm64") echo "aarch64-unknown-linux-gnu" > /tmp/rust_target ;; \
+        "linux/amd64") echo "x86_64-unknown-linux-gnu" > /tmp/rust_target ;; \
+        *) echo "x86_64-unknown-linux-gnu" > /tmp/rust_target ;; \
+    esac
+
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json
+
+# Cook dependencies with target
+RUN RUST_TARGET=$(cat /tmp/rust_target) && \
+    cargo chef cook --release --recipe-path recipe.json --target $RUST_TARGET
+
 COPY . .
-RUN cargo build --release
+
+# Build the application
+RUN RUST_TARGET=$(cat /tmp/rust_target) && \
+    GIT_VERSION=${GIT_VERSION} cargo build --release --target $RUST_TARGET && \
+    cp target/$RUST_TARGET/release/liftlog /app/liftlog
 
 # Stage 4: Runtime
 FROM gcr.io/distroless/cc-debian12
 
-COPY --from=builder /app/target/release/liftlog /liftlog
+COPY --from=builder /app/liftlog /liftlog
 
 VOLUME /data
 


### PR DESCRIPTION
## Summary
- Add multi-architecture Docker image support for `linux/amd64` and `linux/arm64`
- Enable cross-compilation using docker buildx with platform-specific toolchains
- Add `GIT_VERSION` build arg for version injection during build

## Test plan
- [ ] Build image for amd64: `docker buildx build --platform linux/amd64 -t liftlog:amd64 .`
- [ ] Build image for arm64: `docker buildx build --platform linux/arm64 -t liftlog:arm64 .`
- [ ] Build multi-arch image: `docker buildx build --platform linux/amd64,linux/arm64 -t liftlog:latest .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)