### PR TITLE
feat: sort workout sets by created_at descending

### DIFF
--- a/src/repositories/workout_repo.rs
+++ b/src/repositories/workout_repo.rs
@@ -680,10 +680,11 @@ mod tests {
             .unwrap();
 
         assert_eq!(logs.len(), 3);
+        // With DESC ordering: newest first
         // 105.0 is PR for bench press, 120.0 is PR for squat
-        assert!(!logs[0].is_pr); // 100.0 bench
+        assert!(logs[0].is_pr); // 120.0 squat - PR (created last)
         assert!(logs[1].is_pr); // 105.0 bench - PR
-        assert!(logs[2].is_pr); // 120.0 squat - PR
+        assert!(!logs[2].is_pr); // 100.0 bench (created first)
     }
 
     #[tokio::test]
@@ -882,8 +883,9 @@ mod tests {
             .find_logs_by_session_with_pr(&session.id, "user1")
             .await
             .unwrap();
-        assert!(!logs[0].is_pr); // 100.0 is no longer PR
-        assert!(logs[1].is_pr); // 110.0 is now PR
+        // With DESC ordering: newest (110.0) first
+        assert!(logs[0].is_pr); // 110.0 is now PR (created last)
+        assert!(!logs[1].is_pr); // 100.0 is no longer PR (created first)
     }
 
     #[tokio::test]

--- a/src/repositories/workout_repo.rs
+++ b/src/repositories/workout_repo.rs
@@ -241,7 +241,7 @@ impl WorkoutRepository {
                  FROM workout_logs wl
                  JOIN exercises e ON wl.exercise_id = e.id
                  WHERE wl.session_id = ?
-                 ORDER BY wl.created_at, wl.set_number",
+                 ORDER BY wl.created_at DESC, wl.set_number",
             )?;
             let logs = stmt
                 .query_map(


### PR DESCRIPTION
## Summary
- Sort sets on the single workout page by created_at in descending order, showing the most recent records at the top
- Sets with the same timestamp are still sorted by set_number in ascending order

## Test plan
- [x] Open a workout page with multiple sets and verify the newest set appears at the top
- [x] Add a new set and confirm it appears at the top of the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)