### PR TITLE
feat: add workout sharing functionality

### DIFF
--- a/migrations/009_add_workout_share_token.sql
+++ b/migrations/009_add_workout_share_token.sql
@@ -1,0 +1,6 @@
+-- Add share_token column for sharing workouts publicly
+ALTER TABLE workout_sessions ADD COLUMN share_token TEXT;
+
+-- Create unique index for share_token (only for non-null values)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_workout_sessions_share_token
+    ON workout_sessions(share_token) WHERE share_token IS NOT NULL;

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,7 @@ async fn main() -> anyhow::Result<()> {
     let workouts_state = workouts::WorkoutsState {
         workout_repo: workout_repo.clone(),
         exercise_repo: exercise_repo.clone(),
+        user_repo: user_repo.clone(),
     };
     let exercises_state = exercises::ExercisesState {
         exercise_repo: exercise_repo.clone(),

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -31,6 +31,10 @@ pub const MIGRATIONS: &[(&str, &str)] = &[
         "008_create_sessions.sql",
         include_str!("../migrations/008_create_sessions.sql"),
     ),
+    (
+        "009_add_workout_share_token.sql",
+        include_str!("../migrations/009_add_workout_share_token.sql"),
+    ),
 ];
 
 /// Run all pending migrations on the database pool.

--- a/src/models/workout_session.rs
+++ b/src/models/workout_session.rs
@@ -10,6 +10,7 @@ pub struct WorkoutSession {
     pub user_id: String,
     pub date: NaiveDate,
     pub notes: Option<String>,
+    pub share_token: Option<String>,
     pub created_at: DateTime<Utc>,
 }
 
@@ -20,6 +21,7 @@ impl FromSqliteRow for WorkoutSession {
             user_id: row.get("user_id")?,
             date: row.get("date")?,
             notes: row.get("notes")?,
+            share_token: row.get("share_token")?,
             created_at: row.get("created_at")?,
         })
     }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -56,6 +56,10 @@ pub fn create_router(
             get(workouts::edit_log_page),
         )
         .route("/workouts/{id}/logs/{log_id}", post(workouts::update_log))
+        .route("/workouts/{id}/share", post(workouts::share_workout))
+        .route("/workouts/{id}/revoke-share", post(workouts::revoke_share))
+        // Public shared workout route (no auth required)
+        .route("/shared/{token}", get(workouts::view_shared))
         .with_state(workouts_state)
         // Exercise routes
         .route("/exercises", get(exercises::list))

--- a/templates/workouts/shared.html
+++ b/templates/workouts/shared.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+
+{% block title %}Shared Workout {{ workout.date }} - LiftLog{% endblock %}
+
+{% block content %}
+<h1>Shared Workout: {{ workout.date }}</h1>
+
+<p class="muted">Shared by: <strong>{{ owner_username }}</strong></p>
+
+{% match workout.notes %}
+{% when Some with (notes) %}
+<p class="muted"><em>{{ notes }}</em></p>
+{% when None %}
+{% endmatch %}
+
+<h2>Sets</h2>
+
+{% if logs.is_empty() %}
+<p class="muted">No sets recorded.</p>
+{% else %}
+<div class="sets-list">
+    <div class="sets-header">
+        <div>Exercise</div>
+        <div>Set</div>
+        <div>Weight</div>
+        <div>Reps</div>
+        <div>RPE</div>
+        <div></div>
+    </div>
+    {% for log in logs %}
+    <div class="set-row">
+        <div class="set-cell set-cell-exercise">{{ log.exercise_name }}</div>
+        <div class="set-cell set-cell-set">{{ log.set_number }}</div>
+        <div class="set-cell set-cell-weight">{{ log.weight }}</div>
+        <div class="set-cell set-cell-reps">{{ log.reps }}</div>
+        <div class="set-cell set-cell-rpe">{% match log.rpe %}{% when Some with (r) %}{{ r }}{% when None %}-{% endmatch %}</div>
+        <div class="set-cell set-cell-pr"></div>
+    </div>
+    {% endfor %}
+</div>
+{% endif %}
+
+<div class="link">
+    <p class="muted">This is a shared workout from <a href="/">LiftLog</a>.</p>
+</div>
+{% endblock %}

--- a/templates/workouts/show.html
+++ b/templates/workouts/show.html
@@ -20,22 +20,23 @@
         <button type="submit" class="btn-small btn-inline">[Delete]</button>
     </form>
     {% match share_url %}
-    {% when Some with (url) %}
-    <form action="/workouts/{{ workout.id }}/revoke-share" method="post" style="display:inline;">
-        <button type="submit" class="btn-small btn-inline">[Revoke Share]</button>
-    </form>
     {% when None %}
     <form action="/workouts/{{ workout.id }}/share" method="post" style="display:inline;">
         <button type="submit" class="btn-small btn-inline">[Share]</button>
     </form>
+    {% when Some with (url) %}
     {% endmatch %}
 </div>
 
 {% match share_url %}
 {% when Some with (url) %}
-<div class="share-info">
-    <p>Share link: <a href="{{ url }}" target="_blank">{{ url }}</a>
+<div class="share-info" style="margin: 1rem 0; padding: 0.5rem; background: #f5f5f5; border-left: 3px solid #111;">
+    <p style="margin: 0 0 0.5rem 0;">Share link: <a href="{{ url }}" target="_blank">{{ url }}</a>
     <button type="button" class="btn-small btn-inline" onclick="copyShareLink('{{ url }}')">[Copy]</button></p>
+    <form action="/workouts/{{ workout.id }}/revoke-share" method="post" style="display:inline;"
+          onsubmit="return confirm('Revoke sharing? The link will stop working.');">
+        <button type="submit" class="btn-small btn-inline">[Revoke Share]</button>
+    </form>
 </div>
 {% when None %}
 {% endmatch %}

--- a/templates/workouts/show.html
+++ b/templates/workouts/show.html
@@ -19,7 +19,26 @@
           onsubmit="return confirm('Delete this workout?');">
         <button type="submit" class="btn-small btn-inline">[Delete]</button>
     </form>
+    {% match share_url %}
+    {% when Some with (url) %}
+    <form action="/workouts/{{ workout.id }}/revoke-share" method="post" style="display:inline;">
+        <button type="submit" class="btn-small btn-inline">[Revoke Share]</button>
+    </form>
+    {% when None %}
+    <form action="/workouts/{{ workout.id }}/share" method="post" style="display:inline;">
+        <button type="submit" class="btn-small btn-inline">[Share]</button>
+    </form>
+    {% endmatch %}
 </div>
+
+{% match share_url %}
+{% when Some with (url) %}
+<div class="share-info">
+    <p>Share link: <a href="{{ url }}" target="_blank">{{ url }}</a>
+    <button type="button" class="btn-small btn-inline" onclick="copyShareLink('{{ url }}')">[Copy]</button></p>
+</div>
+{% when None %}
+{% endmatch %}
 
 <h3>Add Set</h3>
 <form method="post" action="/workouts/{{ workout.id }}/logs">
@@ -137,6 +156,15 @@ function cloneSet(exerciseId, weight, reps, rpe) {
     }
     showPRInfo(exerciseId);
     exerciseSelect.scrollIntoView({ behavior: 'smooth' });
+}
+
+function copyShareLink(url) {
+    var fullUrl = window.location.origin + url;
+    navigator.clipboard.writeText(fullUrl).then(function() {
+        alert('Link copied to clipboard!');
+    }, function() {
+        prompt('Copy this link:', fullUrl);
+    });
 }
 </script>
 {% endblock %}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -41,6 +41,7 @@ pub fn create_test_app_with_session(pool: DbPool) -> TestApp {
     let workouts_state = workouts::WorkoutsState {
         workout_repo: workout_repo.clone(),
         exercise_repo: exercise_repo.clone(),
+        user_repo: user_repo.clone(),
     };
     let exercises_state = exercises::ExercisesState {
         exercise_repo: exercise_repo.clone(),

--- a/tests/workout_share_test.rs
+++ b/tests/workout_share_test.rs
@@ -1,0 +1,499 @@
+mod common;
+
+use axum::{
+    body::Body,
+    http::{header, Request, StatusCode},
+};
+use http_body_util::BodyExt;
+use liftlog::models::UserRole;
+use liftlog::repositories::WorkoutRepository;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn test_share_workout_success() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_session(pool.clone());
+
+    let user = common::create_test_user(&pool, "testuser", "password123", UserRole::User).await;
+    let session_cookie = common::create_session_cookie(&pool, &user).await;
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    let workout = common::create_test_workout(
+        &pool,
+        &user.id,
+        chrono::NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
+        Some("Test workout"),
+    )
+    .await;
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(&format!("/workouts/{}/share", workout.id))
+                .header(header::COOKIE, &cookie_header)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Should redirect to workout page
+    assert_eq!(response.status(), StatusCode::SEE_OTHER);
+    assert!(response
+        .headers()
+        .get("location")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .contains(&workout.id));
+
+    // Verify share_token was set
+    let workout_repo = WorkoutRepository::new(pool);
+    let updated = workout_repo
+        .find_session_by_id(&workout.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(updated.share_token.is_some());
+}
+
+#[tokio::test]
+async fn test_view_shared_workout_public() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_session(pool.clone());
+
+    let user = common::create_test_user(&pool, "testuser", "password123", UserRole::User).await;
+    let session_cookie = common::create_session_cookie(&pool, &user).await;
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    let exercise = common::create_test_exercise(&pool, &user.id, "Bench Press", "chest").await;
+    let workout = common::create_test_workout(
+        &pool,
+        &user.id,
+        chrono::NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
+        Some("Shared workout test"),
+    )
+    .await;
+    common::create_test_log(&pool, &workout.id, &exercise.id, 1, 10, 100.0, Some(8)).await;
+
+    // Share the workout
+    let workout_repo = WorkoutRepository::new(pool.clone());
+    let share_token = workout_repo
+        .set_share_token(&workout.id, &user.id)
+        .await
+        .unwrap();
+
+    // View shared workout without auth (new app instance to avoid cookies)
+    let app = common::create_test_app(pool.clone());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(&format!("/shared/{}", share_token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_str = String::from_utf8_lossy(&body);
+
+    // Verify content is shown
+    assert!(body_str.contains("2024-01-15") || body_str.contains("Shared workout test"));
+    assert!(body_str.contains("Bench Press"));
+    assert!(body_str.contains("testuser"));
+}
+
+#[tokio::test]
+async fn test_view_shared_invalid_token_returns_404() {
+    let pool = common::setup_test_db();
+    let app = common::create_test_app(pool);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/shared/invalid-token-12345")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_revoke_share_success() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_session(pool.clone());
+
+    let user = common::create_test_user(&pool, "testuser", "password123", UserRole::User).await;
+    let session_cookie = common::create_session_cookie(&pool, &user).await;
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    let workout = common::create_test_workout(
+        &pool,
+        &user.id,
+        chrono::NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
+        None,
+    )
+    .await;
+
+    // First share the workout
+    let workout_repo = WorkoutRepository::new(pool.clone());
+    let share_token = workout_repo
+        .set_share_token(&workout.id, &user.id)
+        .await
+        .unwrap();
+
+    // Then revoke it
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(&format!("/workouts/{}/revoke-share", workout.id))
+                .header(header::COOKIE, &cookie_header)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::SEE_OTHER);
+
+    // Verify share_token was revoked
+    let updated = workout_repo
+        .find_session_by_id(&workout.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(updated.share_token.is_none());
+
+    // Verify the old token no longer works
+    let app = common::create_test_app(pool.clone());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(&format!("/shared/{}", share_token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_reshare_after_revoke_generates_new_token() {
+    let pool = common::setup_test_db();
+
+    let user = common::create_test_user(&pool, "testuser", "password123", UserRole::User).await;
+    let workout = common::create_test_workout(
+        &pool,
+        &user.id,
+        chrono::NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
+        None,
+    )
+    .await;
+
+    let workout_repo = WorkoutRepository::new(pool.clone());
+
+    // Share
+    let token1 = workout_repo
+        .set_share_token(&workout.id, &user.id)
+        .await
+        .unwrap();
+
+    // Revoke
+    workout_repo
+        .revoke_share_token(&workout.id, &user.id)
+        .await
+        .unwrap();
+
+    // Share again
+    let token2 = workout_repo
+        .set_share_token(&workout.id, &user.id)
+        .await
+        .unwrap();
+
+    // Tokens should be different
+    assert_ne!(token1, token2);
+
+    // Old token should not work
+    let app = common::create_test_app(pool.clone());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(&format!("/shared/{}", token1))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    // New token should work
+    let app2 = common::create_test_app(pool.clone());
+    let response2 = app2
+        .oneshot(
+            Request::builder()
+                .uri(&format!("/shared/{}", token2))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response2.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_cannot_share_others_workout() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_session(pool.clone());
+
+    let user1 = common::create_test_user(&pool, "user1", "password123", UserRole::User).await;
+    let user2 = common::create_test_user(&pool, "user2", "password456", UserRole::User).await;
+
+    // user2 creates workout
+    let workout = common::create_test_workout(
+        &pool,
+        &user2.id,
+        chrono::NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
+        None,
+    )
+    .await;
+
+    // user1 tries to share it
+    let session_cookie = common::create_session_cookie(&pool, &user1).await;
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(&format!("/workouts/{}/share", workout.id))
+                .header(header::COOKIE, &cookie_header)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    // Verify workout was NOT shared
+    let workout_repo = WorkoutRepository::new(pool);
+    let found = workout_repo
+        .find_session_by_id(&workout.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(found.share_token.is_none());
+}
+
+#[tokio::test]
+async fn test_share_requires_auth() {
+    let pool = common::setup_test_db();
+    let app = common::create_test_app(pool.clone());
+
+    let user = common::create_test_user(&pool, "testuser", "password123", UserRole::User).await;
+    let workout = common::create_test_workout(
+        &pool,
+        &user.id,
+        chrono::NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
+        None,
+    )
+    .await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(&format!("/workouts/{}/share", workout.id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Should redirect to login
+    assert_eq!(response.status(), StatusCode::SEE_OTHER);
+    assert_eq!(response.headers().get("location").unwrap(), "/auth/login");
+}
+
+#[tokio::test]
+async fn test_revoke_share_requires_auth() {
+    let pool = common::setup_test_db();
+    let app = common::create_test_app(pool.clone());
+
+    let user = common::create_test_user(&pool, "testuser", "password123", UserRole::User).await;
+    let workout = common::create_test_workout(
+        &pool,
+        &user.id,
+        chrono::NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
+        None,
+    )
+    .await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(&format!("/workouts/{}/revoke-share", workout.id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Should redirect to login
+    assert_eq!(response.status(), StatusCode::SEE_OTHER);
+    assert_eq!(response.headers().get("location").unwrap(), "/auth/login");
+}
+
+#[tokio::test]
+async fn test_cannot_revoke_others_share() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_session(pool.clone());
+
+    let user1 = common::create_test_user(&pool, "user1", "password123", UserRole::User).await;
+    let user2 = common::create_test_user(&pool, "user2", "password456", UserRole::User).await;
+
+    // user2 creates and shares workout
+    let workout = common::create_test_workout(
+        &pool,
+        &user2.id,
+        chrono::NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
+        None,
+    )
+    .await;
+    let workout_repo = WorkoutRepository::new(pool.clone());
+    let share_token = workout_repo
+        .set_share_token(&workout.id, &user2.id)
+        .await
+        .unwrap();
+
+    // user1 tries to revoke it
+    let session_cookie = common::create_session_cookie(&pool, &user1).await;
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(&format!("/workouts/{}/revoke-share", workout.id))
+                .header(header::COOKIE, &cookie_header)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    // Verify workout share was NOT revoked
+    let found = workout_repo
+        .find_session_by_id(&workout.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(found.share_token, Some(share_token));
+}
+
+#[tokio::test]
+async fn test_show_workout_displays_share_button() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_session(pool.clone());
+
+    let user = common::create_test_user(&pool, "testuser", "password123", UserRole::User).await;
+    let session_cookie = common::create_session_cookie(&pool, &user).await;
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    let workout = common::create_test_workout(
+        &pool,
+        &user.id,
+        chrono::NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
+        None,
+    )
+    .await;
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .uri(&format!("/workouts/{}", workout.id))
+                .header(header::COOKIE, &cookie_header)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_str = String::from_utf8_lossy(&body);
+
+    // Should show share button
+    assert!(body_str.contains("[Share]"));
+    // Should not show revoke button or share link
+    assert!(!body_str.contains("[Revoke Share]"));
+    assert!(!body_str.contains("Share link:"));
+}
+
+#[tokio::test]
+async fn test_show_workout_displays_share_link_and_revoke() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_session(pool.clone());
+
+    let user = common::create_test_user(&pool, "testuser", "password123", UserRole::User).await;
+    let session_cookie = common::create_session_cookie(&pool, &user).await;
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    let workout = common::create_test_workout(
+        &pool,
+        &user.id,
+        chrono::NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
+        None,
+    )
+    .await;
+
+    // Share the workout
+    let workout_repo = WorkoutRepository::new(pool.clone());
+    let share_token = workout_repo
+        .set_share_token(&workout.id, &user.id)
+        .await
+        .unwrap();
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .uri(&format!("/workouts/{}", workout.id))
+                .header(header::COOKIE, &cookie_header)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_str = String::from_utf8_lossy(&body);
+
+    // Should show revoke button and share link
+    assert!(body_str.contains("[Revoke Share]"));
+    assert!(body_str.contains("Share link:"));
+    assert!(body_str.contains(&format!("/shared/{}", share_token)));
+    // Should not show share button
+    assert!(!body_str.contains(">[Share]<"));
+}


### PR DESCRIPTION
## Summary
- Add the ability to share individual workouts via public links
- Users can share/revoke sharing, with each share generating a unique token
- Shared workouts are publicly accessible at `/shared/{token}` without authentication

## Changes
- Add `share_token` column to `workout_sessions` table with unique index
- Add repository methods: `set_share_token`, `revoke_share_token`, `find_session_by_share_token`, `find_logs_by_session_for_share`
- Add handlers: `share_workout`, `revoke_share`, `view_shared`
- Update `show.html` with share/revoke buttons and copy link functionality
- Add `shared.html` template for public workout view
- Add 11 integration tests and 8 unit tests

## Test plan
- [x] `cargo test` - all 158 tests pass
- [x] `cargo clippy` - no warnings
- [ ] Manual testing: share workout → copy link → view in incognito → revoke → verify 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)