### PR TITLE
chore: switch font CDN to Bunny Fonts

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -4,9 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}LiftLog{% endblock %}</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;600;700&family=Overpass+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.bunny.net">
+    <link href="https://fonts.bunny.net/css2?family=Chakra+Petch:wght@400;600;700&family=Overpass+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
     <style>
         /* ============================================
            DESIGN TOKENS


### PR DESCRIPTION
## Summary
- Replace Google Fonts CDN with Bunny Fonts for GDPR compliance
- Drop-in replacement, no visual changes — same fonts (Chakra Petch, Overpass Mono)

## Test plan
- [x] Verify fonts load correctly in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)