### PR TITLE
fix: add graceful shutdown for Docker

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,34 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!("Starting server at http://{}", addr);
 
     let listener = TcpListener::bind(&addr).await?;
-    axum::serve(listener, app).await?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
 
+    tracing::info!("Server shut down gracefully");
     Ok(())
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => { tracing::info!("Received Ctrl+C, shutting down..."); }
+        _ = terminate => { tracing::info!("Received SIGTERM, shutting down..."); }
+    }
 }


### PR DESCRIPTION
## Summary
- Listen for SIGTERM (Docker stop) and Ctrl+C (SIGINT) signals
- Use Axum's `with_graceful_shutdown` to drain in-flight requests before exiting
- Prevents Docker from waiting the full stop timeout before SIGKILL

## Test plan
- [x] `cargo test` — 158 tests passing
- [ ] `docker stop <container>` exits immediately instead of waiting 10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)