### PR TITLE
fix(docker): install cross-compile target against pinned toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,13 @@ FROM chef AS builder
 ARG TARGETPLATFORM
 ARG GIT_VERSION=dev
 
+# Copy the toolchain pin BEFORE any rustup invocation so that rustup resolves
+# against the pinned toolchain (rust-toolchain.toml) rather than whatever patch
+# version the base image happens to ship. Without this the base image's default
+# toolchain gets the cross-compile target installed, and then `cargo build`
+# downloads the pinned toolchain fresh (without the target) and fails.
+COPY rust-toolchain.toml .
+
 # Install cross-compilation toolchain based on target
 RUN case "$TARGETPLATFORM" in \
         "linux/arm64") \


### PR DESCRIPTION
## Summary

- Copy `rust-toolchain.toml` into the builder stage before invoking `rustup target add`, so the cross-compile target is installed against the pinned toolchain instead of the base image's default.
- Fixes the `linux/arm64` Docker build failing on `main` with `error[E0463]: can't find crate for \`core\``.

## Root cause

The builder stage ran `rustup target add aarch64-unknown-linux-gnu` before any source was in `WORKDIR`, so the target attached to the base image's default toolchain (currently 1.94.1). Later, `cargo build` copied the source in (including `rust-toolchain.toml` pinned to 1.94.0), triggering rustup to download a clean 1.94.0 toolchain without the arm64 target — hence the missing `core`.

Same pattern and fix as rdrs#149.

## Test plan

- [ ] `Docker` workflow passes on this PR for both `linux/amd64` and `linux/arm64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)