### PR TITLE
refactor: simplify codebase across handlers, repositories, and infra

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -11,13 +11,22 @@ pub fn create_pool(database_url: &str) -> Result<DbPool, r2d2::Error> {
     // Remove query parameters (e.g., ?mode=rwc)
     let path = path.split('?').next().unwrap_or(path);
 
-    let manager = if path == ":memory:" {
-        SqliteConnectionManager::memory()
-    } else {
-        SqliteConnectionManager::file(Path::new(path))
-    };
+    if path == ":memory:" {
+        return Pool::builder()
+            .max_size(1)
+            .build(SqliteConnectionManager::memory());
+    }
 
-    Pool::builder().max_size(5).build(manager)
+    // WAL gives concurrent readers; busy_timeout absorbs lock contention from
+    // the spawn_blocking pool (which runs many short writes via r2d2).
+    let manager = SqliteConnectionManager::file(Path::new(path)).with_init(|conn| {
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL;\
+             PRAGMA synchronous=NORMAL;\
+             PRAGMA busy_timeout=5000;",
+        )
+    });
+    Pool::builder().max_size(10).build(manager)
 }
 
 #[allow(dead_code)]

--- a/src/db.rs
+++ b/src/db.rs
@@ -34,3 +34,65 @@ pub fn create_memory_pool() -> Result<DbPool, r2d2::Error> {
     let manager = SqliteConnectionManager::memory();
     Pool::builder().max_size(1).build(manager)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// File-pool test holder that deletes the DB file (and WAL/SHM siblings) on drop.
+    struct TempDbPath(std::path::PathBuf);
+
+    impl TempDbPath {
+        fn new() -> Self {
+            let mut path = std::env::temp_dir();
+            path.push(format!("liftlog-test-{}.sqlite3", uuid::Uuid::new_v4()));
+            Self(path)
+        }
+
+        fn url(&self) -> String {
+            format!("sqlite:{}", self.0.display())
+        }
+    }
+
+    impl Drop for TempDbPath {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.0);
+            let _ = std::fs::remove_file(format!("{}-wal", self.0.display()));
+            let _ = std::fs::remove_file(format!("{}-shm", self.0.display()));
+        }
+    }
+
+    #[test]
+    fn create_pool_with_memory_url() {
+        let pool = create_pool("sqlite::memory:").expect("memory pool");
+        let conn = pool.get().expect("get conn");
+        let one: i64 = conn
+            .query_row("SELECT 1", [], |row| row.get(0))
+            .expect("query");
+        assert_eq!(one, 1);
+    }
+
+    #[test]
+    fn create_pool_with_file_url_enables_wal_pragmas() {
+        let tmp = TempDbPath::new();
+        let pool = create_pool(&tmp.url()).expect("file pool");
+
+        let conn = pool.get().expect("get conn");
+        let mode: String = conn
+            .query_row("PRAGMA journal_mode", [], |row| row.get(0))
+            .expect("journal_mode");
+        assert_eq!(mode.to_lowercase(), "wal");
+
+        let sync: i64 = conn
+            .query_row("PRAGMA synchronous", [], |row| row.get(0))
+            .expect("synchronous");
+        // NORMAL == 1 (FULL == 2, OFF == 0).
+        assert_eq!(sync, 1);
+    }
+
+    #[test]
+    fn create_pool_strips_query_params_and_sqlite_prefix() {
+        let pool = create_pool("sqlite::memory:?mode=rwc").expect("pool");
+        assert!(pool.get().is_ok());
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,7 +23,6 @@ pub enum AppError {
     Forbidden(String),
 
     #[error("Bad request: {0}")]
-    #[allow(dead_code)]
     BadRequest(String),
 
     #[error("Validation error: {0}")]
@@ -35,6 +34,18 @@ pub enum AppError {
 
     #[error("Password hash error")]
     PasswordHash,
+}
+
+impl From<askama::Error> for AppError {
+    fn from(err: askama::Error) -> Self {
+        AppError::Internal(err.to_string())
+    }
+}
+
+impl From<tokio::task::JoinError> for AppError {
+    fn from(err: tokio::task::JoinError) -> Self {
+        AppError::Internal(err.to_string())
+    }
 }
 
 impl IntoResponse for AppError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -91,3 +91,24 @@ impl IntoResponse for AppError {
 }
 
 pub type Result<T> = std::result::Result<T, AppError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn askama_error_converts_to_internal() {
+        let err: AppError = askama::Error::Fmt.into();
+        assert!(matches!(err, AppError::Internal(_)));
+    }
+
+    #[tokio::test]
+    async fn join_error_converts_to_internal() {
+        let handle: tokio::task::JoinHandle<()> = tokio::task::spawn(async {
+            panic!("intentional panic for test");
+        });
+        let join_err = handle.await.expect_err("join must fail after panic");
+        let app_err: AppError = join_err.into();
+        assert!(matches!(app_err, AppError::Internal(_)));
+    }
+}

--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -19,7 +19,6 @@ pub struct AuthState {
     pub session_repo: SessionRepository,
 }
 
-// Templates
 #[derive(Template)]
 #[template(path = "auth/login.html")]
 struct LoginTemplate {
@@ -44,30 +43,33 @@ struct NewUserTemplate {
 struct UsersListTemplate {
     user: AuthUser,
     users: Vec<User>,
-    is_admin: bool,
 }
 
-// Handlers
+/// Returns the validation error message, or `None` if the form is valid.
+fn validate_credentials(form: &CreateUser) -> Option<&'static str> {
+    if form.username.trim().is_empty() {
+        Some("Username is required")
+    } else if form.password.len() < 6 {
+        Some("Password must be at least 6 characters")
+    } else {
+        None
+    }
+}
+
 pub async fn login_page(State(state): State<AuthState>, request: Request) -> Result<Response> {
-    // Redirect to dashboard if already logged in (sliding_session_middleware
-    // injects ValidatedSession into request extensions when the cookie is valid).
+    // sliding_session_middleware injects ValidatedSession into request
+    // extensions when the cookie is valid; bounce already-logged-in users.
     if request.extensions().get::<ValidatedSession>().is_some() {
         return Ok(Redirect::to("/").into_response());
     }
 
-    // Check if any users exist
     let user_count = state.user_repo.count().await?;
     if user_count == 0 {
         return Ok(Redirect::to("/auth/setup").into_response());
     }
 
     let template = LoginTemplate { error: None };
-    Ok(Html(
-        template
-            .render()
-            .map_err(|e| AppError::Internal(e.to_string()))?,
-    )
-    .into_response())
+    Ok(Html(template.render()?).into_response())
 }
 
 pub async fn login_submit(
@@ -83,11 +85,6 @@ pub async fn login_submit(
     match user {
         Some(user) => {
             let token = state.session_repo.create(&user.id).await?;
-            // Lazily clean up expired sessions
-            let repo = state.session_repo.clone();
-            tokio::spawn(async move {
-                let _ = repo.cleanup_expired().await;
-            });
             let jar = jar.add(create_session_cookie(&token));
             Ok((jar, Redirect::to("/")).into_response())
         }
@@ -95,30 +92,19 @@ pub async fn login_submit(
             let template = LoginTemplate {
                 error: Some("Invalid username or password".to_string()),
             };
-            Ok(Html(
-                template
-                    .render()
-                    .map_err(|e| AppError::Internal(e.to_string()))?,
-            )
-            .into_response())
+            Ok(Html(template.render()?).into_response())
         }
     }
 }
 
 pub async fn setup_page(State(state): State<AuthState>) -> Result<Response> {
-    // Only allow setup if no users exist
     let user_count = state.user_repo.count().await?;
     if user_count > 0 {
         return Ok(Redirect::to("/auth/login").into_response());
     }
 
     let template = SetupTemplate { error: None };
-    Ok(Html(
-        template
-            .render()
-            .map_err(|e| AppError::Internal(e.to_string()))?,
-    )
-    .into_response())
+    Ok(Html(template.render()?).into_response())
 }
 
 pub async fn setup_submit(
@@ -126,44 +112,23 @@ pub async fn setup_submit(
     jar: CookieJar,
     Form(form): Form<CreateUser>,
 ) -> Result<Response> {
-    // Only allow setup if no users exist
     let user_count = state.user_repo.count().await?;
     if user_count > 0 {
         return Ok(Redirect::to("/auth/login").into_response());
     }
 
-    // Validate input
-    if form.username.trim().is_empty() {
+    if let Some(message) = validate_credentials(&form) {
         let template = SetupTemplate {
-            error: Some("Username is required".to_string()),
+            error: Some(message.to_string()),
         };
-        return Ok(Html(
-            template
-                .render()
-                .map_err(|e| AppError::Internal(e.to_string()))?,
-        )
-        .into_response());
+        return Ok(Html(template.render()?).into_response());
     }
 
-    if form.password.len() < 6 {
-        let template = SetupTemplate {
-            error: Some("Password must be at least 6 characters".to_string()),
-        };
-        return Ok(Html(
-            template
-                .render()
-                .map_err(|e| AppError::Internal(e.to_string()))?,
-        )
-        .into_response());
-    }
-
-    // Create the first user as admin
     let user = state
         .user_repo
         .create(&form.username, &form.password, UserRole::Admin)
         .await?;
 
-    // Auto login — create DB session
     let token = state.session_repo.create(&user.id).await?;
     let jar = jar.add(create_session_cookie(&token));
 
@@ -185,12 +150,7 @@ pub async fn new_user_page(admin_user: AdminUser) -> Result<Response> {
         user: admin_user.0,
         error: None,
     };
-    Ok(Html(
-        template
-            .render()
-            .map_err(|e| AppError::Internal(e.to_string()))?,
-    )
-    .into_response())
+    Ok(Html(template.render()?).into_response())
 }
 
 pub async fn new_user_submit(
@@ -198,34 +158,14 @@ pub async fn new_user_submit(
     admin_user: AdminUser,
     Form(form): Form<CreateUser>,
 ) -> Result<Response> {
-    // Validate input
-    if form.username.trim().is_empty() {
+    if let Some(message) = validate_credentials(&form) {
         let template = NewUserTemplate {
             user: admin_user.0,
-            error: Some("Username is required".to_string()),
+            error: Some(message.to_string()),
         };
-        return Ok(Html(
-            template
-                .render()
-                .map_err(|e| AppError::Internal(e.to_string()))?,
-        )
-        .into_response());
+        return Ok(Html(template.render()?).into_response());
     }
 
-    if form.password.len() < 6 {
-        let template = NewUserTemplate {
-            user: admin_user.0,
-            error: Some("Password must be at least 6 characters".to_string()),
-        };
-        return Ok(Html(
-            template
-                .render()
-                .map_err(|e| AppError::Internal(e.to_string()))?,
-        )
-        .into_response());
-    }
-
-    // Check if username already exists
     if state
         .user_repo
         .find_by_username(&form.username)
@@ -236,15 +176,9 @@ pub async fn new_user_submit(
             user: admin_user.0,
             error: Some("Username already exists".to_string()),
         };
-        return Ok(Html(
-            template
-                .render()
-                .map_err(|e| AppError::Internal(e.to_string()))?,
-        )
-        .into_response());
+        return Ok(Html(template.render()?).into_response());
     }
 
-    // Create user with regular user role
     state
         .user_repo
         .create(&form.username, &form.password, UserRole::User)
@@ -255,18 +189,11 @@ pub async fn new_user_submit(
 
 pub async fn users_list(State(state): State<AuthState>, auth_user: AuthUser) -> Result<Response> {
     let users = state.user_repo.find_all().await?;
-    let is_admin = auth_user.is_admin();
     let template = UsersListTemplate {
         user: auth_user,
         users,
-        is_admin,
     };
-    Ok(Html(
-        template
-            .render()
-            .map_err(|e| AppError::Internal(e.to_string()))?,
-    )
-    .into_response())
+    Ok(Html(template.render()?).into_response())
 }
 
 pub async fn delete_user(
@@ -274,7 +201,6 @@ pub async fn delete_user(
     admin_user: AdminUser,
     Path(user_id): Path<String>,
 ) -> Result<Response> {
-    // Prevent self-delete
     if admin_user.id == user_id {
         return Err(AppError::BadRequest(
             "Cannot delete your own account".to_string(),

--- a/src/handlers/dashboard.rs
+++ b/src/handlers/dashboard.rs
@@ -4,7 +4,7 @@ use axum::{
     response::{Html, IntoResponse, Response},
 };
 
-use crate::error::{AppError, Result};
+use crate::error::Result;
 use crate::middleware::AuthUser;
 use crate::models::WorkoutSession;
 use crate::repositories::WorkoutRepository;
@@ -50,10 +50,5 @@ pub async fn index(State(state): State<DashboardState>, auth_user: AuthUser) -> 
         recent_workouts,
     };
 
-    Ok(Html(
-        template
-            .render()
-            .map_err(|e| AppError::Internal(e.to_string()))?,
-    )
-    .into_response())
+    Ok(Html(template.render()?).into_response())
 }

--- a/src/handlers/exercises.rs
+++ b/src/handlers/exercises.rs
@@ -5,7 +5,7 @@ use axum::{
     Form,
 };
 
-use crate::error::{AppError, Result};
+use crate::error::Result;
 use crate::middleware::AuthUser;
 use crate::models::exercise::{ExerciseCategory, CATEGORIES};
 use crate::models::{CreateExercise, Exercise, UpdateExercise};
@@ -53,12 +53,7 @@ pub async fn list(State(state): State<ExercisesState>, auth_user: AuthUser) -> R
         categories: CATEGORIES,
     };
 
-    Ok(Html(
-        template
-            .render()
-            .map_err(|e| AppError::Internal(e.to_string()))?,
-    )
-    .into_response())
+    Ok(Html(template.render()?).into_response())
 }
 
 pub async fn new_page(auth_user: AuthUser) -> Result<Response> {
@@ -68,12 +63,7 @@ pub async fn new_page(auth_user: AuthUser) -> Result<Response> {
         error: None,
     };
 
-    Ok(Html(
-        template
-            .render()
-            .map_err(|e| AppError::Internal(e.to_string()))?,
-    )
-    .into_response())
+    Ok(Html(template.render()?).into_response())
 }
 
 pub async fn create(
@@ -87,12 +77,7 @@ pub async fn create(
             categories: CATEGORIES,
             error: Some("Exercise name is required".to_string()),
         };
-        return Ok(Html(
-            template
-                .render()
-                .map_err(|e| AppError::Internal(e.to_string()))?,
-        )
-        .into_response());
+        return Ok(Html(template.render()?).into_response());
     }
 
     state
@@ -108,17 +93,7 @@ pub async fn edit_page(
     auth_user: AuthUser,
     Path(id): Path<String>,
 ) -> Result<Response> {
-    let exercise = state
-        .exercise_repo
-        .find_by_id(&id)
-        .await?
-        .ok_or_else(|| AppError::NotFound("Exercise not found".to_string()))?;
-
-    if exercise.user_id != auth_user.id {
-        return Err(AppError::Forbidden(
-            "You can only edit your own exercises".to_string(),
-        ));
-    }
+    let exercise = state.exercise_repo.find_owned(&id, &auth_user.id).await?;
 
     let template = EditExerciseTemplate {
         user: auth_user,
@@ -127,12 +102,7 @@ pub async fn edit_page(
         error: None,
     };
 
-    Ok(Html(
-        template
-            .render()
-            .map_err(|e| AppError::Internal(e.to_string()))?,
-    )
-    .into_response())
+    Ok(Html(template.render()?).into_response())
 }
 
 pub async fn update(
@@ -141,17 +111,7 @@ pub async fn update(
     Path(id): Path<String>,
     Form(form): Form<UpdateExercise>,
 ) -> Result<Response> {
-    let exercise = state
-        .exercise_repo
-        .find_by_id(&id)
-        .await?
-        .ok_or_else(|| AppError::NotFound("Exercise not found".to_string()))?;
-
-    if exercise.user_id != auth_user.id {
-        return Err(AppError::Forbidden(
-            "You can only edit your own exercises".to_string(),
-        ));
-    }
+    let exercise = state.exercise_repo.find_owned(&id, &auth_user.id).await?;
 
     if form.name.trim().is_empty() {
         let template = EditExerciseTemplate {
@@ -160,12 +120,7 @@ pub async fn update(
             categories: CATEGORIES,
             error: Some("Exercise name is required".to_string()),
         };
-        return Ok(Html(
-            template
-                .render()
-                .map_err(|e| AppError::Internal(e.to_string()))?,
-        )
-        .into_response());
+        return Ok(Html(template.render()?).into_response());
     }
 
     state
@@ -181,17 +136,7 @@ pub async fn delete(
     auth_user: AuthUser,
     Path(id): Path<String>,
 ) -> Result<Response> {
-    let exercise = state
-        .exercise_repo
-        .find_by_id(&id)
-        .await?
-        .ok_or_else(|| AppError::NotFound("Exercise not found".to_string()))?;
-
-    if exercise.user_id != auth_user.id {
-        return Err(AppError::Forbidden(
-            "You can only delete your own exercises".to_string(),
-        ));
-    }
+    state.exercise_repo.find_owned(&id, &auth_user.id).await?;
 
     state.exercise_repo.delete(&id, &auth_user.id).await?;
 

--- a/src/handlers/settings.rs
+++ b/src/handlers/settings.rs
@@ -6,7 +6,7 @@ use axum::{
 };
 use serde::Deserialize;
 
-use crate::error::{AppError, Result};
+use crate::error::Result;
 use crate::middleware::AuthUser;
 use crate::repositories::{SessionListRow, SessionRepository, UserRepository};
 use crate::version::GIT_VERSION;
@@ -32,29 +32,27 @@ struct SettingsTemplate {
     error: Option<String>,
     success: Option<String>,
     sessions: Vec<SessionListRow>,
-    current_token: String,
 }
 
-fn render_settings(template: SettingsTemplate) -> Result<Response> {
-    Ok(Html(
-        template
-            .render()
-            .map_err(|e| AppError::Internal(e.to_string()))?,
-    )
-    .into_response())
+async fn render_page(
+    state: &SettingsState,
+    auth_user: AuthUser,
+    error: Option<String>,
+    success: Option<String>,
+) -> Result<Response> {
+    let sessions = state.session_repo.list_for_user(&auth_user.id).await?;
+    let template = SettingsTemplate {
+        user: auth_user,
+        git_version: GIT_VERSION,
+        error,
+        success,
+        sessions,
+    };
+    Ok(Html(template.render()?).into_response())
 }
 
 pub async fn index(State(state): State<SettingsState>, auth_user: AuthUser) -> Result<Response> {
-    let sessions = state.session_repo.list_for_user(&auth_user.id).await?;
-    let current_token = auth_user.session_token.clone();
-    render_settings(SettingsTemplate {
-        user: auth_user,
-        git_version: GIT_VERSION,
-        error: None,
-        success: None,
-        sessions,
-        current_token,
-    })
+    render_page(&state, auth_user, None, None).await
 }
 
 pub async fn change_password(
@@ -62,74 +60,50 @@ pub async fn change_password(
     auth_user: AuthUser,
     Form(form): Form<ChangePasswordForm>,
 ) -> Result<Response> {
-    let sessions = state.session_repo.list_for_user(&auth_user.id).await?;
-    let current_token = auth_user.session_token.clone();
+    let validation_error = if form.new_password != form.confirm_password {
+        Some("New passwords do not match")
+    } else if form.new_password.len() < 6 {
+        Some("New password must be at least 6 characters")
+    } else {
+        None
+    };
 
-    // Validate: passwords match
-    if form.new_password != form.confirm_password {
-        return render_settings(SettingsTemplate {
-            user: auth_user,
-            git_version: GIT_VERSION,
-            error: Some("New passwords do not match".to_string()),
-            success: None,
-            sessions,
-            current_token,
-        });
+    if let Some(message) = validation_error {
+        return render_page(&state, auth_user, Some(message.to_string()), None).await;
     }
 
-    // Validate: minimum length
-    if form.new_password.len() < 6 {
-        return render_settings(SettingsTemplate {
-            user: auth_user,
-            git_version: GIT_VERSION,
-            error: Some("New password must be at least 6 characters".to_string()),
-            success: None,
-            sessions,
-            current_token,
-        });
-    }
-
-    // Verify current password
     let verified = state
         .user_repo
         .verify_password(&auth_user.username, &form.current_password)
         .await?;
 
     if verified.is_none() {
-        return render_settings(SettingsTemplate {
-            user: auth_user,
-            git_version: GIT_VERSION,
-            error: Some("Current password is incorrect".to_string()),
-            success: None,
-            sessions,
-            current_token,
-        });
+        return render_page(
+            &state,
+            auth_user,
+            Some("Current password is incorrect".to_string()),
+            None,
+        )
+        .await;
     }
 
-    // Change password
     state
         .user_repo
         .change_password(&auth_user.id, &form.new_password)
         .await?;
 
-    // Invalidate all other sessions
     state
         .session_repo
         .delete_all_for_user_except(&auth_user.id, &auth_user.session_token)
         .await?;
 
-    // Reload sessions so the rendered list reflects the just-revoked siblings.
-    let fresh_sessions = state.session_repo.list_for_user(&auth_user.id).await?;
-    render_settings(SettingsTemplate {
-        user: auth_user,
-        git_version: GIT_VERSION,
-        error: None,
-        success: Some(
-            "Password changed successfully. All other sessions have been logged out.".to_string(),
-        ),
-        sessions: fresh_sessions,
-        current_token,
-    })
+    render_page(
+        &state,
+        auth_user,
+        None,
+        Some("Password changed successfully. All other sessions have been logged out.".to_string()),
+    )
+    .await
 }
 
 pub async fn logout_others(
@@ -141,14 +115,11 @@ pub async fn logout_others(
         .delete_all_for_user_except(&auth_user.id, &auth_user.session_token)
         .await?;
 
-    let sessions = state.session_repo.list_for_user(&auth_user.id).await?;
-    let current_token = auth_user.session_token.clone();
-    render_settings(SettingsTemplate {
-        user: auth_user,
-        git_version: GIT_VERSION,
-        error: None,
-        success: Some("Logged out of all other devices.".to_string()),
-        sessions,
-        current_token,
-    })
+    render_page(
+        &state,
+        auth_user,
+        None,
+        Some("Logged out of all other devices.".to_string()),
+    )
+    .await
 }

--- a/src/handlers/stats.rs
+++ b/src/handlers/stats.rs
@@ -73,12 +73,7 @@ pub async fn index(State(state): State<StatsState>, auth_user: AuthUser) -> Resu
         prs,
     };
 
-    Ok(Html(
-        template
-            .render()
-            .map_err(|e| AppError::Internal(e.to_string()))?,
-    )
-    .into_response())
+    Ok(Html(template.render()?).into_response())
 }
 
 pub async fn exercise_stats(
@@ -109,12 +104,7 @@ pub async fn exercise_stats(
         pr,
     };
 
-    Ok(Html(
-        template
-            .render()
-            .map_err(|e| AppError::Internal(e.to_string()))?,
-    )
-    .into_response())
+    Ok(Html(template.render()?).into_response())
 }
 
 pub async fn prs_list(State(state): State<StatsState>, auth_user: AuthUser) -> Result<Response> {
@@ -128,10 +118,5 @@ pub async fn prs_list(State(state): State<StatsState>, auth_user: AuthUser) -> R
         prs,
     };
 
-    Ok(Html(
-        template
-            .render()
-            .map_err(|e| AppError::Internal(e.to_string()))?,
-    )
-    .into_response())
+    Ok(Html(template.render()?).into_response())
 }

--- a/src/handlers/workouts.rs
+++ b/src/handlers/workouts.rs
@@ -23,7 +23,6 @@ pub struct WorkoutsState {
     pub user_repo: UserRepository,
 }
 
-// Templates
 #[derive(Template)]
 #[template(path = "workouts/list.html")]
 struct WorkoutsListTemplate {
@@ -80,13 +79,11 @@ struct EditLogTemplate {
     error: Option<String>,
 }
 
-// Query params
 #[derive(Deserialize)]
 pub struct ListQuery {
     page: Option<i64>,
 }
 
-// Handlers
 pub async fn list(
     State(state): State<WorkoutsState>,
     auth_user: AuthUser,
@@ -114,12 +111,7 @@ pub async fn list(
         total_pages,
     };
 
-    Ok(Html(
-        template
-            .render()
-            .map_err(|e| AppError::Internal(e.to_string()))?,
-    )
-    .into_response())
+    Ok(Html(template.render()?).into_response())
 }
 
 pub async fn new_page(auth_user: AuthUser) -> Result<Response> {
@@ -131,12 +123,7 @@ pub async fn new_page(auth_user: AuthUser) -> Result<Response> {
         error: None,
     };
 
-    Ok(Html(
-        template
-            .render()
-            .map_err(|e| AppError::Internal(e.to_string()))?,
-    )
-    .into_response())
+    Ok(Html(template.render()?).into_response())
 }
 
 pub async fn create(
@@ -159,14 +146,8 @@ pub async fn show(
 ) -> Result<Response> {
     let workout = state
         .workout_repo
-        .find_session_by_id(&id)
-        .await?
-        .ok_or_else(|| AppError::NotFound("Workout not found".to_string()))?;
-
-    // Verify ownership
-    if workout.user_id != auth_user.id {
-        return Err(AppError::NotFound("Workout not found".to_string()));
-    }
+        .find_owned_session(&id, &auth_user.id)
+        .await?;
 
     let logs = state
         .workout_repo
@@ -197,12 +178,7 @@ pub async fn show(
         error: None,
     };
 
-    Ok(Html(
-        template
-            .render()
-            .map_err(|e| AppError::Internal(e.to_string()))?,
-    )
-    .into_response())
+    Ok(Html(template.render()?).into_response())
 }
 
 pub async fn edit_page(
@@ -212,13 +188,8 @@ pub async fn edit_page(
 ) -> Result<Response> {
     let workout = state
         .workout_repo
-        .find_session_by_id(&id)
-        .await?
-        .ok_or_else(|| AppError::NotFound("Workout not found".to_string()))?;
-
-    if workout.user_id != auth_user.id {
-        return Err(AppError::NotFound("Workout not found".to_string()));
-    }
+        .find_owned_session(&id, &auth_user.id)
+        .await?;
 
     let template = EditWorkoutTemplate {
         user: auth_user,
@@ -226,12 +197,7 @@ pub async fn edit_page(
         error: None,
     };
 
-    Ok(Html(
-        template
-            .render()
-            .map_err(|e| AppError::Internal(e.to_string()))?,
-    )
-    .into_response())
+    Ok(Html(template.render()?).into_response())
 }
 
 #[derive(Deserialize)]
@@ -266,31 +232,22 @@ pub async fn delete(
     Ok(Redirect::to("/workouts").into_response())
 }
 
-// Workout Logs
 pub async fn add_log(
     State(state): State<WorkoutsState>,
     auth_user: AuthUser,
     Path(session_id): Path<String>,
     Form(form): Form<CreateWorkoutLog>,
 ) -> Result<Response> {
-    // Verify session ownership
-    let session = state
+    state
         .workout_repo
-        .find_session_by_id(&session_id)
-        .await?
-        .ok_or_else(|| AppError::NotFound("Workout not found".to_string()))?;
+        .find_owned_session(&session_id, &auth_user.id)
+        .await?;
 
-    if session.user_id != auth_user.id {
-        return Err(AppError::NotFound("Workout not found".to_string()));
-    }
-
-    // Get next set number
     let set_number = state
         .workout_repo
         .get_next_set_number(&session_id, &form.exercise_id)
         .await?;
 
-    // Create the log (PR is computed dynamically)
     state
         .workout_repo
         .create_log(
@@ -311,16 +268,10 @@ pub async fn delete_log(
     auth_user: AuthUser,
     Path((session_id, log_id)): Path<(String, String)>,
 ) -> Result<Response> {
-    // Verify session ownership
-    let session = state
+    state
         .workout_repo
-        .find_session_by_id(&session_id)
-        .await?
-        .ok_or_else(|| AppError::NotFound("Workout not found".to_string()))?;
-
-    if session.user_id != auth_user.id {
-        return Err(AppError::NotFound("Workout not found".to_string()));
-    }
+        .find_owned_session(&session_id, &auth_user.id)
+        .await?;
 
     state.workout_repo.delete_log(&log_id, &session_id).await?;
 
@@ -332,30 +283,21 @@ pub async fn edit_log_page(
     auth_user: AuthUser,
     Path((session_id, log_id)): Path<(String, String)>,
 ) -> Result<Response> {
-    // Verify session ownership
     let session = state
         .workout_repo
-        .find_session_by_id(&session_id)
-        .await?
-        .ok_or_else(|| AppError::NotFound("Workout not found".to_string()))?;
+        .find_owned_session(&session_id, &auth_user.id)
+        .await?;
 
-    if session.user_id != auth_user.id {
-        return Err(AppError::NotFound("Workout not found".to_string()));
-    }
-
-    // Get the log
     let log = state
         .workout_repo
         .find_log_by_id(&log_id)
         .await?
         .ok_or_else(|| AppError::NotFound("Log not found".to_string()))?;
 
-    // Verify log belongs to this session
     if log.session_id != session_id {
         return Err(AppError::NotFound("Log not found".to_string()));
     }
 
-    // Get exercise name
     let exercise = state
         .exercise_repo
         .find_by_id(&log.exercise_id)
@@ -370,12 +312,7 @@ pub async fn edit_log_page(
         error: None,
     };
 
-    Ok(Html(
-        template
-            .render()
-            .map_err(|e| AppError::Internal(e.to_string()))?,
-    )
-    .into_response())
+    Ok(Html(template.render()?).into_response())
 }
 
 pub async fn update_log(
@@ -384,16 +321,10 @@ pub async fn update_log(
     Path((session_id, log_id)): Path<(String, String)>,
     Form(form): Form<UpdateWorkoutLog>,
 ) -> Result<Response> {
-    // Verify session ownership
-    let session = state
+    state
         .workout_repo
-        .find_session_by_id(&session_id)
-        .await?
-        .ok_or_else(|| AppError::NotFound("Workout not found".to_string()))?;
-
-    if session.user_id != auth_user.id {
-        return Err(AppError::NotFound("Workout not found".to_string()));
-    }
+        .find_owned_session(&session_id, &auth_user.id)
+        .await?;
 
     state
         .workout_repo
@@ -403,23 +334,15 @@ pub async fn update_log(
     Ok(Redirect::to(&format!("/workouts/{}", session_id)).into_response())
 }
 
-// Share functionality
-
 pub async fn share_workout(
     State(state): State<WorkoutsState>,
     auth_user: AuthUser,
     Path(id): Path<String>,
 ) -> Result<Response> {
-    // Verify session ownership
-    let session = state
+    state
         .workout_repo
-        .find_session_by_id(&id)
-        .await?
-        .ok_or_else(|| AppError::NotFound("Workout not found".to_string()))?;
-
-    if session.user_id != auth_user.id {
-        return Err(AppError::NotFound("Workout not found".to_string()));
-    }
+        .find_owned_session(&id, &auth_user.id)
+        .await?;
 
     state
         .workout_repo
@@ -434,16 +357,10 @@ pub async fn revoke_share(
     auth_user: AuthUser,
     Path(id): Path<String>,
 ) -> Result<Response> {
-    // Verify session ownership
-    let session = state
+    state
         .workout_repo
-        .find_session_by_id(&id)
-        .await?
-        .ok_or_else(|| AppError::NotFound("Workout not found".to_string()))?;
-
-    if session.user_id != auth_user.id {
-        return Err(AppError::NotFound("Workout not found".to_string()));
-    }
+        .find_owned_session(&id, &auth_user.id)
+        .await?;
 
     state
         .workout_repo
@@ -480,10 +397,5 @@ pub async fn view_shared(
         owner_username: owner.username,
     };
 
-    Ok(Html(
-        template
-            .render()
-            .map_err(|e| AppError::Internal(e.to_string()))?,
-    )
-    .into_response())
+    Ok(Html(template.render()?).into_response())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,23 @@ async fn main() -> anyhow::Result<()> {
     let workout_repo = WorkoutRepository::new(pool.clone());
     let session_repo = SessionRepository::new(pool.clone());
 
+    // Periodic background sweep of expired session rows. validate_and_touch
+    // already lazily deletes stale rows it sees, but orphans (sessions never
+    // revisited) need this sweep to avoid unbounded table growth.
+    {
+        let session_repo = session_repo.clone();
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(std::time::Duration::from_secs(60 * 60));
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                if let Err(e) = session_repo.cleanup_expired().await {
+                    tracing::warn!(error = ?e, "session cleanup_expired failed");
+                }
+            }
+        });
+    }
+
     // Create handler states
     let auth_state = auth::AuthState {
         user_repo: user_repo.clone(),

--- a/src/middleware/auth.rs
+++ b/src/middleware/auth.rs
@@ -107,15 +107,15 @@ pub async fn sliding_session_middleware(
         // Set-Cookie (e.g. logout's removal cookie). Appending after it
         // would let the refreshed cookie override the removal in the
         // browser.
+        let cookie_prefix = format!("{}=", crate::session::SESSION_COOKIE_NAME);
         let already_set = response
             .headers()
             .get_all(axum::http::header::SET_COOKIE)
             .iter()
             .any(|v| {
-                v.to_str().ok().is_some_and(|s| {
-                    s.trim_start()
-                        .starts_with(&format!("{}=", crate::session::SESSION_COOKIE_NAME))
-                })
+                v.to_str()
+                    .ok()
+                    .is_some_and(|s| s.trim_start().starts_with(&cookie_prefix))
             });
         if !already_set {
             let cookie = create_session_cookie(&tok);

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -46,11 +46,12 @@ pub const MIGRATIONS: &[(&str, &str)] = &[
 /// This function tracks which migrations have been applied in a `_migrations` table
 /// and only runs migrations that haven't been applied yet.
 pub fn run_migrations(pool: &DbPool) -> anyhow::Result<()> {
+    use std::collections::HashSet;
+
     tracing::info!("Running migrations...");
 
     let conn = pool.get()?;
 
-    // Create migrations tracking table if it doesn't exist
     conn.execute(
         "CREATE TABLE IF NOT EXISTS _migrations (
             name TEXT PRIMARY KEY,
@@ -59,17 +60,16 @@ pub fn run_migrations(pool: &DbPool) -> anyhow::Result<()> {
         [],
     )?;
 
-    for (filename, sql) in MIGRATIONS {
-        // Check if migration was already applied
-        let already_applied: bool = conn
-            .query_row(
-                "SELECT COUNT(*) > 0 FROM _migrations WHERE name = ?",
-                [filename],
-                |row| row.get(0),
-            )
-            .unwrap_or(false);
+    let applied: HashSet<String> = {
+        let mut stmt = conn.prepare("SELECT name FROM _migrations")?;
+        let rows = stmt
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<rusqlite::Result<HashSet<String>>>()?;
+        rows
+    };
 
-        if already_applied {
+    for (filename, sql) in MIGRATIONS {
+        if applied.contains(*filename) {
             tracing::debug!("Skipping already applied migration: {}", filename);
             continue;
         }
@@ -77,8 +77,6 @@ pub fn run_migrations(pool: &DbPool) -> anyhow::Result<()> {
         tracing::info!("Running migration: {}", filename);
 
         conn.execute_batch(sql)?;
-
-        // Record that migration was applied
         conn.execute("INSERT INTO _migrations (name) VALUES (?)", [filename])?;
     }
 

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -98,3 +98,36 @@ pub fn run_migrations_for_tests(pool: &DbPool) -> Result<(), Box<dyn std::error:
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::create_memory_pool;
+
+    #[test]
+    fn run_migrations_creates_tracking_table_and_records_each_migration() {
+        let pool = create_memory_pool().expect("memory pool");
+        run_migrations(&pool).expect("first run");
+
+        let conn = pool.get().unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM _migrations", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count as usize, MIGRATIONS.len());
+    }
+
+    #[test]
+    fn run_migrations_is_idempotent() {
+        let pool = create_memory_pool().expect("memory pool");
+        run_migrations(&pool).expect("first run");
+        // Second invocation must not re-apply or error; the HashSet path
+        // should short-circuit each migration as already applied.
+        run_migrations(&pool).expect("second run");
+
+        let conn = pool.get().unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM _migrations", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count as usize, MIGRATIONS.len());
+    }
+}

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -23,7 +23,14 @@ impl UserRole {
     pub fn parse(s: &str) -> Self {
         match s {
             "admin" => UserRole::Admin,
-            _ => UserRole::User,
+            "user" => UserRole::User,
+            other => {
+                tracing::warn!(
+                    role = other,
+                    "unknown user role in DB; defaulting to UserRole::User",
+                );
+                UserRole::User
+            }
         }
     }
 

--- a/src/repositories/exercise_repo.rs
+++ b/src/repositories/exercise_repo.rs
@@ -24,8 +24,7 @@ impl ExerciseRepository {
             let result = stmt.query_row([&id], Exercise::from_row).optional()?;
             Ok(result)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     #[allow(dead_code)]
@@ -39,8 +38,7 @@ impl ExerciseRepository {
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             Ok(exercises)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     #[allow(dead_code)]
@@ -56,8 +54,22 @@ impl ExerciseRepository {
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             Ok(exercises)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
+    }
+
+    /// Fetch an exercise owned by `user_id`. Returns `NotFound` if no such row,
+    /// `Forbidden` if it exists but belongs to another user.
+    pub async fn find_owned(&self, id: &str, user_id: &str) -> Result<Exercise> {
+        let exercise = self
+            .find_by_id(id)
+            .await?
+            .ok_or_else(|| AppError::NotFound("Exercise not found".to_string()))?;
+        if exercise.user_id != user_id {
+            return Err(AppError::Forbidden(
+                "You can only modify your own exercises".to_string(),
+            ));
+        }
+        Ok(exercise)
     }
 
     pub async fn find_available_for_user(&self, user_id: &str) -> Result<Vec<Exercise>> {
@@ -72,25 +84,7 @@ impl ExerciseRepository {
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             Ok(exercises)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
-    }
-
-    #[allow(dead_code)]
-    pub async fn find_user_custom(&self, user_id: &str) -> Result<Vec<Exercise>> {
-        let pool = self.pool.clone();
-        let user_id = user_id.to_string();
-        tokio::task::spawn_blocking(move || {
-            let conn = pool.get()?;
-            let mut stmt =
-                conn.prepare("SELECT * FROM exercises WHERE user_id = ? ORDER BY category, name")?;
-            let exercises = stmt
-                .query_map([&user_id], Exercise::from_row)?
-                .collect::<rusqlite::Result<Vec<_>>>()?;
-            Ok(exercises)
-        })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     pub async fn create(&self, name: &str, category: &str, user_id: &str) -> Result<Exercise> {
@@ -118,8 +112,7 @@ impl ExerciseRepository {
             )?;
             Ok(())
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))??;
+        .await??;
 
         Ok(exercise)
     }
@@ -144,8 +137,7 @@ impl ExerciseRepository {
             )?;
             Ok(rows > 0)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     pub async fn delete(&self, id: &str, user_id: &str) -> Result<bool> {
@@ -160,8 +152,7 @@ impl ExerciseRepository {
             )?;
             Ok(rows > 0)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 }
 

--- a/src/repositories/session_repo.rs
+++ b/src/repositories/session_repo.rs
@@ -48,8 +48,7 @@ impl SessionRepository {
             )?;
             Ok(token_clone)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     /// Validate the session for a given token and, if the throttle window has
@@ -100,8 +99,7 @@ impl SessionRepository {
                 new_expires_at: None,
             }))
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     /// Delete a single session (logout).
@@ -114,8 +112,7 @@ impl SessionRepository {
             conn.execute("DELETE FROM sessions WHERE token = ?", [&token])?;
             Ok(())
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     /// Delete all sessions for a user except the given token (for password change).
@@ -132,8 +129,7 @@ impl SessionRepository {
             )?;
             Ok(())
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     /// List all unexpired sessions for a user, newest-touched first.
@@ -160,8 +156,7 @@ impl SessionRepository {
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             Ok(rows)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     /// Batch delete all expired sessions.
@@ -177,8 +172,7 @@ impl SessionRepository {
             )?;
             Ok(())
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 }
 

--- a/src/repositories/user_repo.rs
+++ b/src/repositories/user_repo.rs
@@ -27,8 +27,7 @@ impl UserRepository {
             let count: i64 = conn.query_row("SELECT COUNT(*) FROM users", [], |row| row.get(0))?;
             Ok(count)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     #[allow(dead_code)]
@@ -41,8 +40,7 @@ impl UserRepository {
             let result = stmt.query_row([&id], User::from_row).optional()?;
             Ok(result)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     pub async fn find_by_username(&self, username: &str) -> Result<Option<User>> {
@@ -54,8 +52,7 @@ impl UserRepository {
             let result = stmt.query_row([&username], User::from_row).optional()?;
             Ok(result)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     pub async fn find_all(&self) -> Result<Vec<User>> {
@@ -68,8 +65,7 @@ impl UserRepository {
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             Ok(users)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     pub async fn create(&self, username: &str, password: &str, role: UserRole) -> Result<User> {
@@ -102,8 +98,7 @@ impl UserRepository {
             )?;
             Ok(())
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))??;
+        .await??;
 
         Ok(user)
     }
@@ -121,8 +116,7 @@ impl UserRepository {
             )?;
             Ok(rows > 0)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     pub async fn verify_password(&self, username: &str, password: &str) -> Result<Option<User>> {
@@ -148,8 +142,7 @@ impl UserRepository {
             let rows = conn.execute("DELETE FROM users WHERE id = ?", [&id])?;
             Ok(rows > 0)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     pub async fn update_role(&self, id: &str, role: UserRole) -> Result<bool> {
@@ -163,8 +156,7 @@ impl UserRepository {
             )?;
             Ok(rows > 0)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 }
 

--- a/src/repositories/workout_repo.rs
+++ b/src/repositories/workout_repo.rs
@@ -50,9 +50,21 @@ impl WorkoutRepository {
             )?;
             Ok(())
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))??;
+        .await??;
 
+        Ok(session)
+    }
+
+    /// Fetch a session owned by `user_id`. Returns `NotFound` for both
+    /// missing rows and rows belonging to another user (don't leak existence).
+    pub async fn find_owned_session(&self, id: &str, user_id: &str) -> Result<WorkoutSession> {
+        let session = self
+            .find_session_by_id(id)
+            .await?
+            .ok_or_else(|| AppError::NotFound("Workout not found".to_string()))?;
+        if session.user_id != user_id {
+            return Err(AppError::NotFound("Workout not found".to_string()));
+        }
         Ok(session)
     }
 
@@ -65,8 +77,7 @@ impl WorkoutRepository {
             let result = stmt.query_row([&id], WorkoutSession::from_row).optional()?;
             Ok(result)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     #[allow(dead_code)]
@@ -82,8 +93,7 @@ impl WorkoutRepository {
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             Ok(sessions)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     pub async fn find_sessions_by_user_paginated(
@@ -104,8 +114,7 @@ impl WorkoutRepository {
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             Ok(sessions)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     pub async fn count_sessions_by_user(&self, user_id: &str) -> Result<i64> {
@@ -120,8 +129,7 @@ impl WorkoutRepository {
             )?;
             Ok(count)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     pub async fn update_session(
@@ -151,8 +159,7 @@ impl WorkoutRepository {
             };
             Ok(rows > 0)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     pub async fn delete_session(&self, id: &str, user_id: &str) -> Result<bool> {
@@ -167,8 +174,7 @@ impl WorkoutRepository {
             )?;
             Ok(rows > 0)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     // Workout Logs
@@ -214,8 +220,7 @@ impl WorkoutRepository {
             )?;
             Ok(())
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))??;
+        .await??;
 
         Ok(log)
     }
@@ -252,8 +257,7 @@ impl WorkoutRepository {
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             Ok(logs)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     #[allow(dead_code)]
@@ -266,8 +270,7 @@ impl WorkoutRepository {
             let result = stmt.query_row([&id], WorkoutLog::from_row).optional()?;
             Ok(result)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     pub async fn delete_log(&self, id: &str, session_id: &str) -> Result<bool> {
@@ -282,8 +285,7 @@ impl WorkoutRepository {
             )?;
             Ok(rows > 0)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     pub async fn update_log(
@@ -305,8 +307,7 @@ impl WorkoutRepository {
             )?;
             Ok(rows > 0)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     pub async fn get_next_set_number(&self, session_id: &str, exercise_id: &str) -> Result<i32> {
@@ -325,8 +326,7 @@ impl WorkoutRepository {
                 .flatten();
             Ok(result.map(|n| n + 1).unwrap_or(1))
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     // Dynamic Personal Records
@@ -356,8 +356,7 @@ impl WorkoutRepository {
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             Ok(prs)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     /// Get the max weight PR for a specific exercise
@@ -385,8 +384,7 @@ impl WorkoutRepository {
                 .optional()?;
             Ok(result)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     // Statistics
@@ -403,8 +401,7 @@ impl WorkoutRepository {
             )?;
             Ok(count)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     pub async fn count_workouts_this_month(&self, user_id: &str) -> Result<i64> {
@@ -420,8 +417,7 @@ impl WorkoutRepository {
             )?;
             Ok(count)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     pub async fn get_total_volume_this_week(&self, user_id: &str) -> Result<f64> {
@@ -442,8 +438,7 @@ impl WorkoutRepository {
                 .flatten();
             Ok(result.unwrap_or(0.0))
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     /// Get exercise history with dynamically computed is_pr
@@ -481,8 +476,7 @@ impl WorkoutRepository {
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             Ok(logs)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     // Share functionality
@@ -507,8 +501,7 @@ impl WorkoutRepository {
                 Err(AppError::NotFound("Workout not found".to_string()))
             }
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     /// Revoke share token for a workout session
@@ -525,8 +518,7 @@ impl WorkoutRepository {
             )?;
             Ok(rows > 0)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     /// Find a workout session by share token
@@ -541,8 +533,7 @@ impl WorkoutRepository {
                 .optional()?;
             Ok(result)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 
     /// Find logs by session for sharing (without PR calculation)
@@ -568,8 +559,7 @@ impl WorkoutRepository {
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             Ok(logs)
         })
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+        .await?
     }
 }
 

--- a/templates/auth/users.html
+++ b/templates/auth/users.html
@@ -10,7 +10,7 @@
         <h1>Users</h1>
     </div>
 
-    {% if is_admin %}
+    {% if user.is_admin() %}
     <p class="mb-4"><a href="/users/new" class="btn btn-primary">+ Add New User</a></p>
     {% endif %}
 
@@ -20,7 +20,7 @@
                 <th>Username</th>
                 <th>Role</th>
                 <th>Created</th>
-                {% if is_admin %}
+                {% if user.is_admin() %}
                 <th>Actions</th>
                 {% endif %}
             </tr>
@@ -31,7 +31,7 @@
                 <td data-label="Username" style="color: var(--text-primary);">{{ u.username }}</td>
                 <td data-label="Role">{% if u.role.is_admin() %}<span style="color: var(--gold);">{{ u.role.as_str() }}</span>{% else %}{{ u.role.as_str() }}{% endif %}</td>
                 <td data-label="Created">{{ u.created_at.format("%Y-%m-%d %H:%M") }}</td>
-                {% if is_admin %}
+                {% if user.is_admin() %}
                 <td data-label="Actions">
                     {% if u.id != user.id %}
                     <div class="actions">

--- a/templates/settings/index.html
+++ b/templates/settings/index.html
@@ -49,7 +49,7 @@
             {% for s in sessions %}
             <tr>
                 <td>
-                    {% if s.token == current_token %}
+                    {% if s.token == user.session_token %}
                     <strong>This device</strong>
                     {% else %}
                     Other device

--- a/tests/auth_test.rs
+++ b/tests/auth_test.rs
@@ -214,6 +214,64 @@ async fn test_setup_creates_admin_user() {
 }
 
 #[tokio::test]
+async fn test_setup_rejects_empty_username() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_session(pool.clone());
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/auth/setup")
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .body(Body::from("username=&password=adminpass123"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Validation failure re-renders the setup form (200 OK).
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let html = String::from_utf8_lossy(&body);
+    assert!(html.contains("Username is required"));
+
+    // No user should have been created.
+    let user_repo = liftlog::repositories::UserRepository::new(pool);
+    let count = user_repo.count().await.unwrap();
+    assert_eq!(count, 0);
+}
+
+#[tokio::test]
+async fn test_setup_rejects_short_password() {
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_session(pool.clone());
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/auth/setup")
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .body(Body::from("username=admin&password=short"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let html = String::from_utf8_lossy(&body);
+    assert!(html.contains("Password must be at least 6 characters"));
+
+    let user_repo = liftlog::repositories::UserRepository::new(pool);
+    let count = user_repo.count().await.unwrap();
+    assert_eq!(count, 0);
+}
+
+#[tokio::test]
 async fn test_setup_redirects_when_users_exist() {
     let pool = common::setup_test_db();
     let test_app = common::create_test_app_with_session(pool.clone());


### PR DESCRIPTION
## Summary

- Drops ~70 callsites of `map_err(|e| AppError::Internal(e.to_string()))?` boilerplate by adding `From<askama::Error>` and `From<tokio::task::JoinError>` impls for `AppError`.
- Dedupes 11 copies of session/exercise ownership-check blocks via two new helpers (`WorkoutRepository::find_owned_session`, `ExerciseRepository::find_owned`) and dedupes auth credential validation via `validate_credentials`.
- Removes redundant template state (`UsersListTemplate.is_admin`, `SettingsTemplate.current_token`) — the templates now derive from `user`.
- Moves per-login `cleanup_expired` `tokio::spawn` to a single hourly ticker started in `main`, and fixes a wasted `list_for_user` fetch on the settings success path.
- DB: enables `journal_mode=WAL`, `synchronous=NORMAL`, `busy_timeout=5000` on file pools; raises file-pool size from 5 → 10 (memory pool stays at 1).
- `migrations.rs`: bulk-loads applied migration names into a `HashSet` and drops `unwrap_or(false)` that was masking DB errors.
- `UserRole::parse`: logs a warning on unknown role instead of silently downcasting.
- Removes dead `find_user_custom` (byte-identical to `find_available_for_user`) and the stale `#[allow(dead_code)]` on `BadRequest`.
- Cleans up "what" comments in handlers; preserves the few WHY-comments that remain.

Net diff: **-257 lines** (255 inserts / 512 deletes across 18 files).

Driven by a `/simplify` pass with three parallel reviewers (code reuse, code quality, efficiency). Higher-risk and benchmark-dependent follow-ups are tracked in #64.

## Test plan

- [x] `cargo nextest run` — 240 / 240 passing
- [x] `cargo fmt` clean
- [x] `cargo check --tests` clean (only pre-existing unused-helper warnings in `tests/common/mod.rs`)
- [x] Manual smoke: log in, create a workout, change password (verify other sessions are revoked), confirm settings page renders with current device marker
- [x] Verify WAL files appear next to the SQLite DB on first run with a file-backed DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)