### PR TITLE
refactor: consolidate per-handler *State into a single AppState

### DIFF
--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -10,14 +10,8 @@ use crate::error::{AppError, Result};
 use crate::middleware::auth::ValidatedSession;
 use crate::middleware::{AdminUser, AuthUser};
 use crate::models::{CreateUser, LoginCredentials, User, UserRole};
-use crate::repositories::{SessionRepository, UserRepository};
 use crate::session::{create_session_cookie, remove_session_cookie};
-
-#[derive(Clone)]
-pub struct AuthState {
-    pub user_repo: UserRepository,
-    pub session_repo: SessionRepository,
-}
+use crate::state::AppState;
 
 #[derive(Template)]
 #[template(path = "auth/login.html")]
@@ -56,7 +50,7 @@ fn validate_credentials(form: &CreateUser) -> Option<&'static str> {
     }
 }
 
-pub async fn login_page(State(state): State<AuthState>, request: Request) -> Result<Response> {
+pub async fn login_page(State(state): State<AppState>, request: Request) -> Result<Response> {
     // sliding_session_middleware injects ValidatedSession into request
     // extensions when the cookie is valid; bounce already-logged-in users.
     if request.extensions().get::<ValidatedSession>().is_some() {
@@ -73,7 +67,7 @@ pub async fn login_page(State(state): State<AuthState>, request: Request) -> Res
 }
 
 pub async fn login_submit(
-    State(state): State<AuthState>,
+    State(state): State<AppState>,
     jar: CookieJar,
     Form(credentials): Form<LoginCredentials>,
 ) -> Result<Response> {
@@ -97,7 +91,7 @@ pub async fn login_submit(
     }
 }
 
-pub async fn setup_page(State(state): State<AuthState>) -> Result<Response> {
+pub async fn setup_page(State(state): State<AppState>) -> Result<Response> {
     let user_count = state.user_repo.count().await?;
     if user_count > 0 {
         return Ok(Redirect::to("/auth/login").into_response());
@@ -108,7 +102,7 @@ pub async fn setup_page(State(state): State<AuthState>) -> Result<Response> {
 }
 
 pub async fn setup_submit(
-    State(state): State<AuthState>,
+    State(state): State<AppState>,
     jar: CookieJar,
     Form(form): Form<CreateUser>,
 ) -> Result<Response> {
@@ -136,7 +130,7 @@ pub async fn setup_submit(
 }
 
 pub async fn logout(
-    State(state): State<AuthState>,
+    State(state): State<AppState>,
     auth_user: AuthUser,
     jar: CookieJar,
 ) -> Response {
@@ -154,7 +148,7 @@ pub async fn new_user_page(admin_user: AdminUser) -> Result<Response> {
 }
 
 pub async fn new_user_submit(
-    State(state): State<AuthState>,
+    State(state): State<AppState>,
     admin_user: AdminUser,
     Form(form): Form<CreateUser>,
 ) -> Result<Response> {
@@ -187,7 +181,7 @@ pub async fn new_user_submit(
     Ok(Redirect::to("/users").into_response())
 }
 
-pub async fn users_list(State(state): State<AuthState>, auth_user: AuthUser) -> Result<Response> {
+pub async fn users_list(State(state): State<AppState>, auth_user: AuthUser) -> Result<Response> {
     let users = state.user_repo.find_all().await?;
     let template = UsersListTemplate {
         user: auth_user,
@@ -197,7 +191,7 @@ pub async fn users_list(State(state): State<AuthState>, auth_user: AuthUser) -> 
 }
 
 pub async fn delete_user(
-    State(state): State<AuthState>,
+    State(state): State<AppState>,
     admin_user: AdminUser,
     Path(user_id): Path<String>,
 ) -> Result<Response> {
@@ -213,7 +207,7 @@ pub async fn delete_user(
 }
 
 pub async fn promote_user(
-    State(state): State<AuthState>,
+    State(state): State<AppState>,
     _admin_user: AdminUser,
     Path(user_id): Path<String>,
 ) -> Result<Response> {

--- a/src/handlers/dashboard.rs
+++ b/src/handlers/dashboard.rs
@@ -7,12 +7,7 @@ use axum::{
 use crate::error::Result;
 use crate::middleware::AuthUser;
 use crate::models::WorkoutSession;
-use crate::repositories::WorkoutRepository;
-
-#[derive(Clone)]
-pub struct DashboardState {
-    pub workout_repo: WorkoutRepository,
-}
+use crate::state::AppState;
 
 #[derive(Template)]
 #[template(path = "dashboard/index.html")]
@@ -24,7 +19,7 @@ struct DashboardTemplate {
     recent_workouts: Vec<WorkoutSession>,
 }
 
-pub async fn index(State(state): State<DashboardState>, auth_user: AuthUser) -> Result<Response> {
+pub async fn index(State(state): State<AppState>, auth_user: AuthUser) -> Result<Response> {
     let workouts_this_week = state
         .workout_repo
         .count_workouts_this_week(&auth_user.id)

--- a/src/handlers/exercises.rs
+++ b/src/handlers/exercises.rs
@@ -9,12 +9,7 @@ use crate::error::Result;
 use crate::middleware::AuthUser;
 use crate::models::exercise::{ExerciseCategory, CATEGORIES};
 use crate::models::{CreateExercise, Exercise, UpdateExercise};
-use crate::repositories::ExerciseRepository;
-
-#[derive(Clone)]
-pub struct ExercisesState {
-    pub exercise_repo: ExerciseRepository,
-}
+use crate::state::AppState;
 
 #[derive(Template)]
 #[template(path = "exercises/list.html")]
@@ -41,7 +36,7 @@ struct EditExerciseTemplate {
     error: Option<String>,
 }
 
-pub async fn list(State(state): State<ExercisesState>, auth_user: AuthUser) -> Result<Response> {
+pub async fn list(State(state): State<AppState>, auth_user: AuthUser) -> Result<Response> {
     let exercises = state
         .exercise_repo
         .find_available_for_user(&auth_user.id)
@@ -67,7 +62,7 @@ pub async fn new_page(auth_user: AuthUser) -> Result<Response> {
 }
 
 pub async fn create(
-    State(state): State<ExercisesState>,
+    State(state): State<AppState>,
     auth_user: AuthUser,
     Form(form): Form<CreateExercise>,
 ) -> Result<Response> {
@@ -89,7 +84,7 @@ pub async fn create(
 }
 
 pub async fn edit_page(
-    State(state): State<ExercisesState>,
+    State(state): State<AppState>,
     auth_user: AuthUser,
     Path(id): Path<String>,
 ) -> Result<Response> {
@@ -106,7 +101,7 @@ pub async fn edit_page(
 }
 
 pub async fn update(
-    State(state): State<ExercisesState>,
+    State(state): State<AppState>,
     auth_user: AuthUser,
     Path(id): Path<String>,
     Form(form): Form<UpdateExercise>,
@@ -132,7 +127,7 @@ pub async fn update(
 }
 
 pub async fn delete(
-    State(state): State<ExercisesState>,
+    State(state): State<AppState>,
     auth_user: AuthUser,
     Path(id): Path<String>,
 ) -> Result<Response> {

--- a/src/handlers/settings.rs
+++ b/src/handlers/settings.rs
@@ -8,14 +8,9 @@ use serde::Deserialize;
 
 use crate::error::Result;
 use crate::middleware::AuthUser;
-use crate::repositories::{SessionListRow, SessionRepository, UserRepository};
+use crate::repositories::SessionListRow;
+use crate::state::AppState;
 use crate::version::GIT_VERSION;
-
-#[derive(Clone)]
-pub struct SettingsState {
-    pub user_repo: UserRepository,
-    pub session_repo: SessionRepository,
-}
 
 #[derive(Deserialize)]
 pub struct ChangePasswordForm {
@@ -35,7 +30,7 @@ struct SettingsTemplate {
 }
 
 async fn render_page(
-    state: &SettingsState,
+    state: &AppState,
     auth_user: AuthUser,
     error: Option<String>,
     success: Option<String>,
@@ -51,12 +46,12 @@ async fn render_page(
     Ok(Html(template.render()?).into_response())
 }
 
-pub async fn index(State(state): State<SettingsState>, auth_user: AuthUser) -> Result<Response> {
+pub async fn index(State(state): State<AppState>, auth_user: AuthUser) -> Result<Response> {
     render_page(&state, auth_user, None, None).await
 }
 
 pub async fn change_password(
-    State(state): State<SettingsState>,
+    State(state): State<AppState>,
     auth_user: AuthUser,
     Form(form): Form<ChangePasswordForm>,
 ) -> Result<Response> {
@@ -106,10 +101,7 @@ pub async fn change_password(
     .await
 }
 
-pub async fn logout_others(
-    State(state): State<SettingsState>,
-    auth_user: AuthUser,
-) -> Result<Response> {
+pub async fn logout_others(State(state): State<AppState>, auth_user: AuthUser) -> Result<Response> {
     state
         .session_repo
         .delete_all_for_user_except(&auth_user.id, &auth_user.session_token)

--- a/src/handlers/stats.rs
+++ b/src/handlers/stats.rs
@@ -7,13 +7,7 @@ use axum::{
 use crate::error::{AppError, Result};
 use crate::middleware::AuthUser;
 use crate::models::{DynamicPR, Exercise, WorkoutLogWithExercise};
-use crate::repositories::{ExerciseRepository, WorkoutRepository};
-
-#[derive(Clone)]
-pub struct StatsState {
-    pub workout_repo: WorkoutRepository,
-    pub exercise_repo: ExerciseRepository,
-}
+use crate::state::AppState;
 
 #[derive(Template)]
 #[template(path = "stats/index.html")]
@@ -42,7 +36,7 @@ struct PrsTemplate {
     prs: Vec<DynamicPR>,
 }
 
-pub async fn index(State(state): State<StatsState>, auth_user: AuthUser) -> Result<Response> {
+pub async fn index(State(state): State<AppState>, auth_user: AuthUser) -> Result<Response> {
     let workouts_this_week = state
         .workout_repo
         .count_workouts_this_week(&auth_user.id)
@@ -77,7 +71,7 @@ pub async fn index(State(state): State<StatsState>, auth_user: AuthUser) -> Resu
 }
 
 pub async fn exercise_stats(
-    State(state): State<StatsState>,
+    State(state): State<AppState>,
     auth_user: AuthUser,
     Path(exercise_id): Path<String>,
 ) -> Result<Response> {
@@ -107,7 +101,7 @@ pub async fn exercise_stats(
     Ok(Html(template.render()?).into_response())
 }
 
-pub async fn prs_list(State(state): State<StatsState>, auth_user: AuthUser) -> Result<Response> {
+pub async fn prs_list(State(state): State<AppState>, auth_user: AuthUser) -> Result<Response> {
     let prs = state
         .workout_repo
         .get_all_prs_by_user(&auth_user.id)

--- a/src/handlers/workouts.rs
+++ b/src/handlers/workouts.rs
@@ -14,14 +14,7 @@ use crate::models::{
     CreateWorkoutLog, CreateWorkoutSession, DynamicPR, Exercise, UpdateWorkoutLog, WorkoutLog,
     WorkoutLogWithExercise, WorkoutSession,
 };
-use crate::repositories::{ExerciseRepository, UserRepository, WorkoutRepository};
-
-#[derive(Clone)]
-pub struct WorkoutsState {
-    pub workout_repo: WorkoutRepository,
-    pub exercise_repo: ExerciseRepository,
-    pub user_repo: UserRepository,
-}
+use crate::state::AppState;
 
 #[derive(Template)]
 #[template(path = "workouts/list.html")]
@@ -85,7 +78,7 @@ pub struct ListQuery {
 }
 
 pub async fn list(
-    State(state): State<WorkoutsState>,
+    State(state): State<AppState>,
     auth_user: AuthUser,
     Query(query): Query<ListQuery>,
 ) -> Result<Response> {
@@ -127,7 +120,7 @@ pub async fn new_page(auth_user: AuthUser) -> Result<Response> {
 }
 
 pub async fn create(
-    State(state): State<WorkoutsState>,
+    State(state): State<AppState>,
     auth_user: AuthUser,
     Form(form): Form<CreateWorkoutSession>,
 ) -> Result<Response> {
@@ -140,7 +133,7 @@ pub async fn create(
 }
 
 pub async fn show(
-    State(state): State<WorkoutsState>,
+    State(state): State<AppState>,
     auth_user: AuthUser,
     Path(id): Path<String>,
 ) -> Result<Response> {
@@ -182,7 +175,7 @@ pub async fn show(
 }
 
 pub async fn edit_page(
-    State(state): State<WorkoutsState>,
+    State(state): State<AppState>,
     auth_user: AuthUser,
     Path(id): Path<String>,
 ) -> Result<Response> {
@@ -207,7 +200,7 @@ pub struct UpdateWorkoutForm {
 }
 
 pub async fn update(
-    State(state): State<WorkoutsState>,
+    State(state): State<AppState>,
     auth_user: AuthUser,
     Path(id): Path<String>,
     Form(form): Form<UpdateWorkoutForm>,
@@ -221,7 +214,7 @@ pub async fn update(
 }
 
 pub async fn delete(
-    State(state): State<WorkoutsState>,
+    State(state): State<AppState>,
     auth_user: AuthUser,
     Path(id): Path<String>,
 ) -> Result<Response> {
@@ -233,7 +226,7 @@ pub async fn delete(
 }
 
 pub async fn add_log(
-    State(state): State<WorkoutsState>,
+    State(state): State<AppState>,
     auth_user: AuthUser,
     Path(session_id): Path<String>,
     Form(form): Form<CreateWorkoutLog>,
@@ -264,7 +257,7 @@ pub async fn add_log(
 }
 
 pub async fn delete_log(
-    State(state): State<WorkoutsState>,
+    State(state): State<AppState>,
     auth_user: AuthUser,
     Path((session_id, log_id)): Path<(String, String)>,
 ) -> Result<Response> {
@@ -279,7 +272,7 @@ pub async fn delete_log(
 }
 
 pub async fn edit_log_page(
-    State(state): State<WorkoutsState>,
+    State(state): State<AppState>,
     auth_user: AuthUser,
     Path((session_id, log_id)): Path<(String, String)>,
 ) -> Result<Response> {
@@ -316,7 +309,7 @@ pub async fn edit_log_page(
 }
 
 pub async fn update_log(
-    State(state): State<WorkoutsState>,
+    State(state): State<AppState>,
     auth_user: AuthUser,
     Path((session_id, log_id)): Path<(String, String)>,
     Form(form): Form<UpdateWorkoutLog>,
@@ -335,7 +328,7 @@ pub async fn update_log(
 }
 
 pub async fn share_workout(
-    State(state): State<WorkoutsState>,
+    State(state): State<AppState>,
     auth_user: AuthUser,
     Path(id): Path<String>,
 ) -> Result<Response> {
@@ -353,7 +346,7 @@ pub async fn share_workout(
 }
 
 pub async fn revoke_share(
-    State(state): State<WorkoutsState>,
+    State(state): State<AppState>,
     auth_user: AuthUser,
     Path(id): Path<String>,
 ) -> Result<Response> {
@@ -371,7 +364,7 @@ pub async fn revoke_share(
 }
 
 pub async fn view_shared(
-    State(state): State<WorkoutsState>,
+    State(state): State<AppState>,
     Path(token): Path<String>,
 ) -> Result<Response> {
     let workout = state

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,5 @@ pub mod models;
 pub mod repositories;
 pub mod routes;
 pub mod session;
+pub mod state;
 pub mod version;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,12 +11,13 @@ mod models;
 mod repositories;
 mod routes;
 mod session;
+mod state;
 mod version;
 
 use config::Config;
-use handlers::{auth, dashboard, exercises, settings, stats, workouts};
 use migrations::run_migrations;
 use repositories::{ExerciseRepository, SessionRepository, UserRepository, WorkoutRepository};
+use state::AppState;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -66,40 +67,15 @@ async fn main() -> anyhow::Result<()> {
         });
     }
 
-    // Create handler states
-    let auth_state = auth::AuthState {
-        user_repo: user_repo.clone(),
-        session_repo: session_repo.clone(),
-    };
-    let dashboard_state = dashboard::DashboardState {
-        workout_repo: workout_repo.clone(),
-    };
-    let workouts_state = workouts::WorkoutsState {
-        workout_repo: workout_repo.clone(),
-        exercise_repo: exercise_repo.clone(),
-        user_repo: user_repo.clone(),
-    };
-    let exercises_state = exercises::ExercisesState {
-        exercise_repo: exercise_repo.clone(),
-    };
-    let stats_state = stats::StatsState {
-        workout_repo: workout_repo.clone(),
-        exercise_repo: exercise_repo.clone(),
-    };
-    let settings_state = settings::SettingsState {
-        user_repo: user_repo.clone(),
-        session_repo: session_repo.clone(),
+    let app_state = AppState {
+        user_repo,
+        exercise_repo,
+        workout_repo,
+        session_repo,
     };
 
     // Build router
-    let app = routes::create_router(
-        auth_state,
-        dashboard_state,
-        workouts_state,
-        exercises_state,
-        stats_state,
-        settings_state,
-    );
+    let app = routes::create_router(app_state);
 
     // Start server
     let addr = config.server_addr();

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -6,17 +6,11 @@ use axum::{
 
 use crate::handlers::{auth, dashboard, exercises, favicon, health, settings, stats, workouts};
 use crate::middleware::sliding_session_middleware;
+use crate::state::AppState;
 
-pub fn create_router(
-    auth_state: auth::AuthState,
-    dashboard_state: dashboard::DashboardState,
-    workouts_state: workouts::WorkoutsState,
-    exercises_state: exercises::ExercisesState,
-    stats_state: stats::StatsState,
-    settings_state: settings::SettingsState,
-) -> Router {
-    let session_repo = auth_state.session_repo.clone();
-    let user_repo = auth_state.user_repo.clone();
+pub fn create_router(state: AppState) -> Router {
+    let session_repo = state.session_repo.clone();
+    let user_repo = state.user_repo.clone();
 
     Router::new()
         // Health check
@@ -26,7 +20,6 @@ pub fn create_router(
         .route("/apple-touch-icon.png", get(favicon::apple_touch_icon))
         // Dashboard
         .route("/", get(dashboard::index))
-        .with_state(dashboard_state)
         // Auth routes
         .route(
             "/auth/login",
@@ -44,7 +37,6 @@ pub fn create_router(
         )
         .route("/users/{id}/delete", post(auth::delete_user))
         .route("/users/{id}/promote", post(auth::promote_user))
-        .with_state(auth_state)
         // Workout routes
         .route("/workouts", get(workouts::list))
         .route("/workouts/new", get(workouts::new_page))
@@ -67,7 +59,6 @@ pub fn create_router(
         .route("/workouts/{id}/revoke-share", post(workouts::revoke_share))
         // Public shared workout route (no auth required)
         .route("/shared/{token}", get(workouts::view_shared))
-        .with_state(workouts_state)
         // Exercise routes
         .route("/exercises", get(exercises::list))
         .route("/exercises/new", get(exercises::new_page))
@@ -75,17 +66,15 @@ pub fn create_router(
         .route("/exercises/{id}/edit", get(exercises::edit_page))
         .route("/exercises/{id}", post(exercises::update))
         .route("/exercises/{id}/delete", post(exercises::delete))
-        .with_state(exercises_state)
         // Stats routes
         .route("/stats", get(stats::index))
         .route("/stats/exercise/{id}", get(stats::exercise_stats))
         .route("/stats/prs", get(stats::prs_list))
-        .with_state(stats_state)
         // Settings routes
         .route("/settings", get(settings::index))
         .route("/settings/password", post(settings::change_password))
         .route("/settings/logout-others", post(settings::logout_others))
-        .with_state(settings_state)
+        .with_state(state)
         // Sliding session: validate cookie, slide expiry, re-issue Set-Cookie on touch
         .layer(from_fn_with_state(
             session_repo.clone(),

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,11 @@
+use crate::repositories::{
+    ExerciseRepository, SessionRepository, UserRepository, WorkoutRepository,
+};
+
+#[derive(Clone)]
+pub struct AppState {
+    pub user_repo: UserRepository,
+    pub exercise_repo: ExerciseRepository,
+    pub workout_repo: WorkoutRepository,
+    pub session_repo: SessionRepository,
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -21,48 +21,17 @@ pub fn create_test_app(pool: DbPool) -> Router {
 }
 
 pub fn create_test_app_with_session(pool: DbPool) -> TestApp {
-    use liftlog::handlers::{auth, dashboard, exercises, settings, stats, workouts};
     use liftlog::repositories::{ExerciseRepository, WorkoutRepository};
+    use liftlog::state::AppState;
 
-    // Create repositories
-    let user_repo = UserRepository::new(pool.clone());
-    let exercise_repo = ExerciseRepository::new(pool.clone());
-    let workout_repo = WorkoutRepository::new(pool.clone());
-    let session_repo = SessionRepository::new(pool.clone());
-
-    // Create handler states
-    let auth_state = auth::AuthState {
-        user_repo: user_repo.clone(),
-        session_repo: session_repo.clone(),
-    };
-    let dashboard_state = dashboard::DashboardState {
-        workout_repo: workout_repo.clone(),
-    };
-    let workouts_state = workouts::WorkoutsState {
-        workout_repo: workout_repo.clone(),
-        exercise_repo: exercise_repo.clone(),
-        user_repo: user_repo.clone(),
-    };
-    let exercises_state = exercises::ExercisesState {
-        exercise_repo: exercise_repo.clone(),
-    };
-    let stats_state = stats::StatsState {
-        workout_repo: workout_repo.clone(),
-        exercise_repo: exercise_repo.clone(),
-    };
-    let settings_state = settings::SettingsState {
-        user_repo: user_repo.clone(),
-        session_repo: session_repo.clone(),
+    let app_state = AppState {
+        user_repo: UserRepository::new(pool.clone()),
+        exercise_repo: ExerciseRepository::new(pool.clone()),
+        workout_repo: WorkoutRepository::new(pool.clone()),
+        session_repo: SessionRepository::new(pool.clone()),
     };
 
-    let router = liftlog::routes::create_router(
-        auth_state,
-        dashboard_state,
-        workouts_state,
-        exercises_state,
-        stats_state,
-        settings_state,
-    );
+    let router = liftlog::routes::create_router(app_state);
 
     TestApp { router }
 }


### PR DESCRIPTION
## Summary
- Replace six near-identical per-handler `*State` wrappers (`AuthState`, `DashboardState`, `WorkoutsState`, `ExercisesState`, `StatsState`, `SettingsState`) with one `AppState` in `src/state.rs`.
- `create_router` now takes a single `AppState` instead of six arguments; `main.rs` and `tests/common/mod.rs` build one state.
- Net `-91` lines of boilerplate, no behavior change.

Refs #64 (item 1)

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -- -D warnings` (matches CI scope)
- [x] `cargo nextest run` — 256/256 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)