### PR TITLE
refactor(tests): centralise session/cookie helpers

### DIFF
--- a/tests/auth_test.rs
+++ b/tests/auth_test.rs
@@ -301,23 +301,15 @@ async fn test_sliding_session_reissues_cookie_when_throttle_elapsed() {
     let user = common::create_test_user(&pool, "alice", "password123", UserRole::User).await;
 
     // Artificially age last_touched_at so the next request slides expiry.
-    let session_repo = liftlog::repositories::SessionRepository::new(pool.clone());
-    let token = session_repo.create(&user.id).await.unwrap();
-    {
-        let conn = pool.get().unwrap();
-        conn.execute(
-            "UPDATE sessions SET last_touched_at = datetime('now', '-2 hours') WHERE token = ?",
-            [&token],
-        )
-        .unwrap();
-    }
+    let token = common::create_session_token(&pool, &user).await;
+    common::age_session_touch(&pool, &token, 2).await;
 
     let app = common::create_test_app(pool);
     let response = app
         .oneshot(
             Request::builder()
                 .uri("/")
-                .header(header::COOKIE, format!("session={}", token))
+                .header(header::COOKIE, common::cookie_header(&token))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -344,15 +336,14 @@ async fn test_sliding_session_no_cookie_when_within_throttle() {
     let user = common::create_test_user(&pool, "alice", "password123", UserRole::User).await;
 
     // Fresh session: last_touched_at is ~now, so within throttle.
-    let session_repo = liftlog::repositories::SessionRepository::new(pool.clone());
-    let token = session_repo.create(&user.id).await.unwrap();
+    let token = common::create_session_token(&pool, &user).await;
 
     let app = common::create_test_app(pool);
     let response = app
         .oneshot(
             Request::builder()
                 .uri("/")
-                .header(header::COOKIE, format!("session={}", token))
+                .header(header::COOKIE, common::cookie_header(&token))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -372,16 +363,8 @@ async fn test_logout_does_not_get_overridden_by_sliding_refresh() {
     let user = common::create_test_user(&pool, "alice", "password123", UserRole::User).await;
 
     // Age the session so the next request triggers a touch.
-    let session_repo = liftlog::repositories::SessionRepository::new(pool.clone());
-    let token = session_repo.create(&user.id).await.unwrap();
-    {
-        let conn = pool.get().unwrap();
-        conn.execute(
-            "UPDATE sessions SET last_touched_at = datetime('now', '-2 hours') WHERE token = ?",
-            [&token],
-        )
-        .unwrap();
-    }
+    let token = common::create_session_token(&pool, &user).await;
+    common::age_session_touch(&pool, &token, 2).await;
 
     let app = common::create_test_app(pool);
     let response = app
@@ -389,7 +372,7 @@ async fn test_logout_does_not_get_overridden_by_sliding_refresh() {
             Request::builder()
                 .method("POST")
                 .uri("/auth/logout")
-                .header(header::COOKIE, format!("session={}", token))
+                .header(header::COOKIE, common::cookie_header(&token))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -423,23 +406,15 @@ async fn test_expired_session_redirects_to_login() {
     let pool = common::setup_test_db();
     let user = common::create_test_user(&pool, "alice", "password123", UserRole::User).await;
 
-    let session_repo = liftlog::repositories::SessionRepository::new(pool.clone());
-    let token = session_repo.create(&user.id).await.unwrap();
-    {
-        let conn = pool.get().unwrap();
-        conn.execute(
-            "UPDATE sessions SET expires_at = datetime('now', '-1 hour') WHERE token = ?",
-            [&token],
-        )
-        .unwrap();
-    }
+    let token = common::create_session_token(&pool, &user).await;
+    common::expire_session(&pool, &token).await;
 
     let app = common::create_test_app(pool);
     let response = app
         .oneshot(
             Request::builder()
                 .uri("/")
-                .header(header::COOKIE, format!("session={}", token))
+                .header(header::COOKIE, common::cookie_header(&token))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -455,15 +430,14 @@ async fn test_login_page_redirects_to_dashboard_when_already_authenticated() {
     let pool = common::setup_test_db();
     let user = common::create_test_user(&pool, "alice", "password123", UserRole::User).await;
 
-    let session_repo = liftlog::repositories::SessionRepository::new(pool.clone());
-    let token = session_repo.create(&user.id).await.unwrap();
+    let token = common::create_session_token(&pool, &user).await;
 
     let app = common::create_test_app(pool);
     let response = app
         .oneshot(
             Request::builder()
                 .uri("/auth/login")
-                .header(header::COOKIE, format!("session={}", token))
+                .header(header::COOKIE, common::cookie_header(&token))
                 .body(Body::empty())
                 .unwrap(),
         )

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -46,15 +46,42 @@ pub async fn create_test_user(
     user_repo.create(username, password, role).await.unwrap()
 }
 
-pub async fn create_session_cookie(pool: &DbPool, user: &User) -> String {
+pub async fn create_session_token(pool: &DbPool, user: &User) -> String {
     let session_repo = SessionRepository::new(pool.clone());
-    let token = session_repo.create(&user.id).await.unwrap();
+    session_repo.create(&user.id).await.unwrap()
+}
+
+pub fn cookie_header(token: &str) -> String {
     format!("session={}", token)
+}
+
+pub async fn create_session_cookie(pool: &DbPool, user: &User) -> String {
+    cookie_header(&create_session_token(pool, user).await)
 }
 
 pub fn extract_cookie_header(set_cookie: &str) -> String {
     // Extract just the cookie name=value part for use in Cookie header
     set_cookie.split(';').next().unwrap_or("").to_string()
+}
+
+#[allow(dead_code)]
+pub async fn age_session_touch(pool: &DbPool, token: &str, hours_ago: u32) {
+    let conn = pool.get().unwrap();
+    let sql = format!(
+        "UPDATE sessions SET last_touched_at = datetime('now', '-{} hours') WHERE token = ?",
+        hours_ago
+    );
+    conn.execute(&sql, [token]).unwrap();
+}
+
+#[allow(dead_code)]
+pub async fn expire_session(pool: &DbPool, token: &str) {
+    let conn = pool.get().unwrap();
+    conn.execute(
+        "UPDATE sessions SET expires_at = datetime('now', '-1 hour') WHERE token = ?",
+        [token],
+    )
+    .unwrap();
 }
 
 // Test data creation helpers

--- a/tests/settings_test.rs
+++ b/tests/settings_test.rs
@@ -236,7 +236,7 @@ async fn test_change_password_invalidates_other_sessions() {
     let token_current = session_repo.create(&user.id).await.unwrap();
     let token_other = session_repo.create(&user.id).await.unwrap();
 
-    let cookie_header = format!("session={}", token_current);
+    let cookie_header = common::cookie_header(&token_current);
 
     let response = test_app
         .router
@@ -282,7 +282,7 @@ async fn test_settings_page_lists_sessions_with_this_device_marker() {
         .oneshot(
             Request::builder()
                 .uri("/settings")
-                .header(header::COOKIE, format!("session={}", current_token))
+                .header(header::COOKIE, common::cookie_header(&current_token))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -315,7 +315,7 @@ async fn test_logout_others_deletes_siblings_only() {
             Request::builder()
                 .method("POST")
                 .uri("/settings/logout-others")
-                .header(header::COOKIE, format!("session={}", current_token))
+                .header(header::COOKIE, common::cookie_header(&current_token))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -348,15 +348,14 @@ async fn test_logout_others_form_has_confirm_attr() {
     let pool = common::setup_test_db();
     let user = common::create_test_user(&pool, "alice", "password123", UserRole::User).await;
 
-    let session_repo = liftlog::repositories::SessionRepository::new(pool.clone());
-    let token = session_repo.create(&user.id).await.unwrap();
+    let token = common::create_session_token(&pool, &user).await;
 
     let app = common::create_test_app(pool);
     let response = app
         .oneshot(
             Request::builder()
                 .uri("/settings")
-                .header(header::COOKIE, format!("session={}", token))
+                .header(header::COOKIE, common::cookie_header(&token))
                 .body(Body::empty())
                 .unwrap(),
         )


### PR DESCRIPTION
## Summary
- Decompose `create_session_cookie` into `create_session_token` + `cookie_header` so call sites that need the token separately don't have to instantiate `SessionRepository` inline.
- Add `age_session_touch(pool, token, hours_ago)` and `expire_session(pool, token)` to replace raw `UPDATE sessions SET …` SQL in `auth_test.rs` (3 sites).
- Replace 8 inline `format!("session={}", token)` with `cookie_header(&token)` across `auth_test.rs` and `settings_test.rs`.
- `create_session_cookie` is preserved as a thin wrapper over the two new helpers so the 60+ existing call sites are unaffected.

Refs #64 (item 7)

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -- -D warnings` (CI scope)
- [x] `cargo nextest run` — 256/256 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)