### PR TITLE
refactor(auth): inline session identity + explicit logout marker

### DIFF
--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -8,7 +8,7 @@ use axum_extra::extract::CookieJar;
 
 use crate::error::{AppError, Result};
 use crate::middleware::auth::ValidatedSession;
-use crate::middleware::{AdminUser, AuthUser};
+use crate::middleware::{AdminUser, AuthUser, SuppressSessionRefresh};
 use crate::models::{CreateUser, LoginCredentials, User, UserRole};
 use crate::session::{create_session_cookie, remove_session_cookie};
 use crate::state::AppState;
@@ -136,7 +136,11 @@ pub async fn logout(
 ) -> Response {
     let _ = state.session_repo.delete(&auth_user.session_token).await;
     let jar = jar.add(remove_session_cookie());
-    (jar, Redirect::to("/auth/login")).into_response()
+    let mut response = (jar, Redirect::to("/auth/login")).into_response();
+    // Tell sliding_session_middleware not to overwrite the removal cookie
+    // with a refreshed one.
+    response.extensions_mut().insert(SuppressSessionRefresh);
+    response
 }
 
 pub async fn new_user_page(admin_user: AdminUser) -> Result<Response> {

--- a/src/middleware/auth.rs
+++ b/src/middleware/auth.rs
@@ -96,21 +96,13 @@ pub async fn sliding_session_middleware(
     let mut response = next.run(request).await;
 
     if let Some(tok) = should_refresh_cookie {
-        // Skip the refresh if the handler already emitted a `session=...`
-        // Set-Cookie (e.g. logout's removal cookie). Appending after it
-        // would let the refreshed cookie override the removal in the
-        // browser.
-        let cookie_prefix = format!("{}=", crate::session::SESSION_COOKIE_NAME);
-        let already_set = response
-            .headers()
-            .get_all(axum::http::header::SET_COOKIE)
-            .iter()
-            .any(|v| {
-                v.to_str()
-                    .ok()
-                    .is_some_and(|s| s.trim_start().starts_with(&cookie_prefix))
-            });
-        if !already_set {
+        // Skip the refresh if the handler explicitly opted out (e.g. logout,
+        // which emits a removal cookie that must not be overwritten).
+        let suppressed = response
+            .extensions()
+            .get::<SuppressSessionRefresh>()
+            .is_some();
+        if !suppressed {
             let cookie = create_session_cookie(&tok);
             let header_value = cookie
                 .to_string()
@@ -124,6 +116,12 @@ pub async fn sliding_session_middleware(
 
     response
 }
+
+/// Response-extension marker that handlers (e.g. `logout`) insert to tell
+/// `sliding_session_middleware` not to append a refreshed session cookie
+/// to this response.
+#[derive(Clone, Copy, Debug)]
+pub struct SuppressSessionRefresh;
 
 pub struct AuthRedirect;
 

--- a/src/middleware/auth.rs
+++ b/src/middleware/auth.rs
@@ -3,12 +3,11 @@ use axum::{
     http::{request::Parts, StatusCode},
     middleware::Next,
     response::{IntoResponse, Redirect, Response},
-    Extension,
 };
 use axum_extra::extract::CookieJar;
 
 use crate::models::UserRole;
-use crate::repositories::{SessionRepository, UserRepository};
+use crate::repositories::SessionRepository;
 use crate::session::{create_session_cookie, get_session_token};
 
 #[derive(Clone, Debug)]
@@ -31,38 +30,30 @@ where
 {
     type Rejection = AuthRedirect;
 
-    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         let validated = parts
             .extensions
             .get::<ValidatedSession>()
             .cloned()
             .ok_or(AuthRedirect)?;
 
-        let Extension(user_repo) = Extension::<UserRepository>::from_request_parts(parts, state)
-            .await
-            .map_err(|_| AuthRedirect)?;
-
-        let user = user_repo
-            .find_by_id(&validated.user_id)
-            .await
-            .map_err(|_| AuthRedirect)?
-            .ok_or(AuthRedirect)?;
-
         Ok(AuthUser {
-            id: user.id,
-            username: user.username,
-            role: user.role,
+            id: validated.user_id,
+            username: validated.username,
+            role: validated.role,
             session_token: validated.session_token,
         })
     }
 }
 
 /// Produced by `sliding_session_middleware` for every request that arrives
-/// with a valid session cookie. Extractors downstream read this from
-/// request extensions instead of re-hitting the database.
+/// with a valid session cookie. Carries the full user identity so the
+/// `AuthUser` extractor doesn't need a second `users` lookup per request.
 #[derive(Clone, Debug)]
 pub struct ValidatedSession {
     pub user_id: String,
+    pub username: String,
+    pub role: UserRole,
     pub session_token: String,
 }
 
@@ -84,6 +75,8 @@ pub async fn sliding_session_middleware(
             Ok(Some(outcome)) => {
                 request.extensions_mut().insert(ValidatedSession {
                     user_id: outcome.user_id,
+                    username: outcome.username,
+                    role: outcome.role,
                     session_token: tok.to_string(),
                 });
                 if outcome.new_expires_at.is_some() {

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1,3 +1,3 @@
 pub mod auth;
 
-pub use auth::{sliding_session_middleware, AdminUser, AuthUser};
+pub use auth::{sliding_session_middleware, AdminUser, AuthUser, SuppressSessionRefresh};

--- a/src/repositories/session_repo.rs
+++ b/src/repositories/session_repo.rs
@@ -4,15 +4,20 @@ use uuid::Uuid;
 
 use crate::db::DbPool;
 use crate::error::{AppError, Result};
+use crate::models::UserRole;
 
 #[derive(Clone)]
 pub struct SessionRepository {
     pool: DbPool,
 }
 
-/// Returned by [`SessionRepository::validate_and_touch`].
+/// Returned by [`SessionRepository::validate_and_touch`]. Carries the full
+/// session+user identity so downstream extractors don't need a second
+/// `users` lookup per request.
 pub struct ValidateAndTouchOutcome {
     pub user_id: String,
+    pub username: String,
+    pub role: UserRole,
     /// `Some(new_expires)` iff this call wrote a new `last_touched_at` /
     /// `expires_at`. `None` means the call landed inside the throttle window.
     pub new_expires_at: Option<chrono::DateTime<Utc>>,
@@ -64,18 +69,35 @@ impl SessionRepository {
         tokio::task::spawn_blocking(move || {
             let conn = pool.get()?;
 
-            let row: Option<(String, chrono::DateTime<Utc>, chrono::DateTime<Utc>)> = conn
+            type Row = (
+                String,
+                chrono::DateTime<Utc>,
+                chrono::DateTime<Utc>,
+                String,
+                String,
+            );
+            let row: Option<Row> = conn
                 .query_row(
-                    "SELECT user_id, expires_at, last_touched_at \
-                     FROM sessions WHERE token = ?",
+                    "SELECT s.user_id, s.expires_at, s.last_touched_at, u.username, u.role \
+                     FROM sessions s JOIN users u ON u.id = s.user_id \
+                     WHERE s.token = ?",
                     [&token],
-                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                    |row| {
+                        Ok((
+                            row.get(0)?,
+                            row.get(1)?,
+                            row.get(2)?,
+                            row.get(3)?,
+                            row.get(4)?,
+                        ))
+                    },
                 )
                 .optional()?;
 
-            let Some((user_id, expires_at, last_touched_at)) = row else {
+            let Some((user_id, expires_at, last_touched_at, username, role_str)) = row else {
                 return Ok::<_, AppError>(None);
             };
+            let role = UserRole::parse(&role_str);
 
             if expires_at <= now {
                 conn.execute("DELETE FROM sessions WHERE token = ?", [&token])?;
@@ -90,12 +112,16 @@ impl SessionRepository {
                 )?;
                 return Ok(Some(ValidateAndTouchOutcome {
                     user_id,
+                    username,
+                    role,
                     new_expires_at: Some(new_expires),
                 }));
             }
 
             Ok(Some(ValidateAndTouchOutcome {
                 user_id,
+                username,
+                role,
                 new_expires_at: None,
             }))
         })

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,7 +1,7 @@
 use axum::{
     middleware::from_fn_with_state,
     routing::{get, post},
-    Extension, Router,
+    Router,
 };
 
 use crate::handlers::{auth, dashboard, exercises, favicon, health, settings, stats, workouts};
@@ -10,7 +10,6 @@ use crate::state::AppState;
 
 pub fn create_router(state: AppState) -> Router {
     let session_repo = state.session_repo.clone();
-    let user_repo = state.user_repo.clone();
 
     Router::new()
         // Health check
@@ -77,10 +76,7 @@ pub fn create_router(state: AppState) -> Router {
         .with_state(state)
         // Sliding session: validate cookie, slide expiry, re-issue Set-Cookie on touch
         .layer(from_fn_with_state(
-            session_repo.clone(),
+            session_repo,
             sliding_session_middleware,
         ))
-        // Repos via Extension layer so extractors can pull them
-        .layer(Extension(session_repo))
-        .layer(Extension(user_repo))
 }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -75,8 +75,5 @@ pub fn create_router(state: AppState) -> Router {
         .route("/settings/logout-others", post(settings::logout_others))
         .with_state(state)
         // Sliding session: validate cookie, slide expiry, re-issue Set-Cookie on touch
-        .layer(from_fn_with_state(
-            session_repo,
-            sliding_session_middleware,
-        ))
+        .layer(from_fn_with_state(session_repo, sliding_session_middleware))
 }


### PR DESCRIPTION
Bundles two related cleanups against `src/middleware/auth.rs` (split into separate commits for review).

## Item 5 — inline user identity in `ValidatedSession`

`sliding_session_middleware` already round-trips to SQLite via `validate_and_touch`. Previously, `AuthUser::from_request_parts` then issued a **second** `users.find_by_id` per authenticated request to recover `username` and `role`.

- Widen `validate_and_touch`'s SELECT to `JOIN users`, return `username` + `role` alongside `user_id`.
- `ValidatedSession` carries the full identity; `AuthUser::from_request_parts` constructs from it directly.
- Side effect: `Extension(UserRepository)` layer in `routes::create_router` was only consumed by the old lookup path and is removed.

## Item 6 — explicit `SuppressSessionRefresh` marker

`sliding_session_middleware` previously detected logout's removal cookie by parsing outgoing `Set-Cookie` headers. Behaviour was correct, contract was implicit and brittle.

- Introduce `SuppressSessionRefresh` response-extension marker.
- `logout` inserts it; middleware checks `response.extensions` instead of re-parsing headers.

Refs #64 (items 5, 6)

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -- -D warnings` (CI scope)
- [x] `cargo nextest run` — 256/256 pass (incl. `test_logout_does_not_get_overridden_by_sliding_refresh`, which directly exercises the item-6 path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)