### PR TITLE
refactor(workouts): show last weight instead of max when adding a set

### DIFF
--- a/src/handlers/workouts.rs
+++ b/src/handlers/workouts.rs
@@ -11,8 +11,8 @@ use crate::error::{AppError, Result};
 use crate::middleware::AuthUser;
 use crate::models::exercise::{ExerciseCategory, CATEGORIES};
 use crate::models::{
-    CreateWorkoutLog, CreateWorkoutSession, DynamicPR, Exercise, UpdateWorkoutLog, WorkoutLog,
-    WorkoutLogWithExercise, WorkoutSession,
+    CreateWorkoutLog, CreateWorkoutSession, Exercise, LastExerciseWeight, UpdateWorkoutLog,
+    WorkoutLog, WorkoutLogWithExercise, WorkoutSession,
 };
 use crate::state::AppState;
 
@@ -41,7 +41,7 @@ struct ShowWorkoutTemplate {
     logs: Vec<WorkoutLogWithExercise>,
     exercises: Vec<Exercise>,
     categories: &'static [ExerciseCategory],
-    exercise_prs: Vec<DynamicPR>,
+    exercise_last_weights: Vec<LastExerciseWeight>,
     share_url: Option<String>,
     error: Option<String>,
 }
@@ -150,9 +150,9 @@ pub async fn show(
         .exercise_repo
         .find_available_for_user(&auth_user.id)
         .await?;
-    let exercise_prs = state
+    let exercise_last_weights = state
         .workout_repo
-        .get_all_prs_by_user(&auth_user.id)
+        .get_last_weight_per_exercise_by_user(&auth_user.id)
         .await?;
 
     let share_url = workout
@@ -166,7 +166,7 @@ pub async fn show(
         logs,
         exercises,
         categories: CATEGORIES,
-        exercise_prs,
+        exercise_last_weights,
         share_url,
         error: None,
     };

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -7,7 +7,7 @@ pub mod workout_session;
 
 pub use exercise::{CreateExercise, Exercise, UpdateExercise};
 pub use from_row::FromSqliteRow;
-pub use personal_record::DynamicPR;
+pub use personal_record::{DynamicPR, LastExerciseWeight};
 pub use user::{CreateUser, LoginCredentials, User, UserRole};
 pub use workout_log::{CreateWorkoutLog, UpdateWorkoutLog, WorkoutLog, WorkoutLogWithExercise};
 pub use workout_session::{CreateWorkoutSession, WorkoutSession};

--- a/src/models/personal_record.rs
+++ b/src/models/personal_record.rs
@@ -23,3 +23,23 @@ impl FromSqliteRow for DynamicPR {
         })
     }
 }
+
+/// Most recently logged weight for a given exercise
+#[derive(Debug, Clone, Serialize)]
+pub struct LastExerciseWeight {
+    pub exercise_id: String,
+    pub exercise_name: String,
+    pub weight: f64,
+    pub logged_at: DateTime<Utc>,
+}
+
+impl FromSqliteRow for LastExerciseWeight {
+    fn from_row(row: &Row) -> rusqlite::Result<Self> {
+        Ok(Self {
+            exercise_id: row.get("exercise_id")?,
+            exercise_name: row.get("exercise_name")?,
+            weight: row.get("weight")?,
+            logged_at: row.get("logged_at")?,
+        })
+    }
+}

--- a/src/repositories/workout_repo.rs
+++ b/src/repositories/workout_repo.rs
@@ -4,7 +4,10 @@ use uuid::Uuid;
 
 use crate::db::DbPool;
 use crate::error::{AppError, Result};
-use crate::models::{DynamicPR, FromSqliteRow, WorkoutLog, WorkoutLogWithExercise, WorkoutSession};
+use crate::models::{
+    DynamicPR, FromSqliteRow, LastExerciseWeight, WorkoutLog, WorkoutLogWithExercise,
+    WorkoutSession,
+};
 
 #[derive(Clone)]
 pub struct WorkoutRepository {
@@ -355,6 +358,34 @@ impl WorkoutRepository {
                 .query_map(rusqlite::params![user_id, user_id], DynamicPR::from_row)?
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             Ok(prs)
+        })
+        .await?
+    }
+
+    /// Get the most recently logged weight per exercise for a user
+    pub async fn get_last_weight_per_exercise_by_user(
+        &self,
+        user_id: &str,
+    ) -> Result<Vec<LastExerciseWeight>> {
+        let pool = self.pool.clone();
+        let user_id = user_id.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.get()?;
+            let mut stmt = conn.prepare(
+                "SELECT wl.exercise_id, e.name as exercise_name,
+                        wl.weight as weight,
+                        MAX(wl.created_at) as logged_at
+                 FROM workout_logs wl
+                 JOIN workout_sessions ws ON wl.session_id = ws.id
+                 JOIN exercises e ON wl.exercise_id = e.id
+                 WHERE ws.user_id = ?
+                 GROUP BY wl.exercise_id
+                 ORDER BY logged_at DESC",
+            )?;
+            let entries = stmt
+                .query_map([&user_id], LastExerciseWeight::from_row)?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            Ok(entries)
         })
         .await?
     }
@@ -1091,6 +1122,65 @@ mod tests {
         let prs = repo.get_all_prs_by_user("user1").await.unwrap();
 
         assert!(prs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_get_last_weight_per_exercise_by_user() {
+        let pool = setup_test_db();
+        create_test_user(&pool, "user1");
+        create_test_exercise(&pool, "ex-bench-press", "user1");
+        create_test_exercise(&pool, "ex-squat", "user1");
+        let repo = WorkoutRepository::new(pool);
+
+        let date = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
+        let session = repo.create_session("user1", date, None).await.unwrap();
+
+        // Bench press: latest set (105) is lower than max (110)
+        repo.create_log(&session.id, "ex-bench-press", 1, 10, 100.0, None)
+            .await
+            .unwrap();
+        repo.create_log(&session.id, "ex-bench-press", 2, 8, 110.0, None)
+            .await
+            .unwrap();
+        repo.create_log(&session.id, "ex-bench-press", 3, 5, 105.0, None)
+            .await
+            .unwrap();
+        // Squat: single set
+        repo.create_log(&session.id, "ex-squat", 1, 5, 150.0, None)
+            .await
+            .unwrap();
+
+        let entries = repo
+            .get_last_weight_per_exercise_by_user("user1")
+            .await
+            .unwrap();
+
+        assert_eq!(entries.len(), 2);
+        let bench = entries
+            .iter()
+            .find(|e| e.exercise_id == "ex-bench-press")
+            .expect("bench entry");
+        let squat = entries
+            .iter()
+            .find(|e| e.exercise_id == "ex-squat")
+            .expect("squat entry");
+        // Last logged weight, NOT the max
+        assert_eq!(bench.weight, 105.0);
+        assert_eq!(squat.weight, 150.0);
+    }
+
+    #[tokio::test]
+    async fn test_get_last_weight_per_exercise_by_user_empty() {
+        let pool = setup_test_db();
+        create_test_user(&pool, "user1");
+        let repo = WorkoutRepository::new(pool);
+
+        let entries = repo
+            .get_last_weight_per_exercise_by_user("user1")
+            .await
+            .unwrap();
+
+        assert!(entries.is_empty());
     }
 
     // Share functionality tests

--- a/templates/workouts/show.html
+++ b/templates/workouts/show.html
@@ -60,7 +60,7 @@
                     </optgroup>
                     {% endfor %}
                 </select>
-                <div id="exercise-pr-info" class="pr-info"></div>
+                <div id="exercise-last-weight-info" class="pr-info"></div>
             </div>
             <div class="form-group">
                 <label for="weight">Weight</label>
@@ -121,38 +121,38 @@
 </main>
 
 <script>
-var exercisePRs = {};
-{% for pr in exercise_prs %}
-exercisePRs["{{ pr.exercise_id }}"] = {
-    weight: {{ pr.value }},
-    date: "{{ pr.achieved_at.format("%Y-%m-%d") }}"
+var exerciseLastWeights = {};
+{% for entry in exercise_last_weights %}
+exerciseLastWeights["{{ entry.exercise_id }}"] = {
+    weight: {{ entry.weight }},
+    date: "{{ entry.logged_at.format("%Y-%m-%d") }}"
 };
 {% endfor %}
 
-var prInfoEl = document.getElementById('exercise-pr-info');
+var lastWeightInfoEl = document.getElementById('exercise-last-weight-info');
 var exerciseSelect = document.getElementById('exercise_id');
 
-function showPRInfo(exerciseId) {
-    if (exerciseId && exercisePRs[exerciseId]) {
-        var pr = exercisePRs[exerciseId];
-        prInfoEl.innerHTML = "Max Weight: " + pr.weight + " kg @ " + pr.date +
-            ' <button type="button" class="btn btn-sm btn-inline" style="background:var(--gold);color:var(--text-inverse);border-color:var(--gold);" onclick="fillMaxWeight()">Fill</button>';
-        prInfoEl.classList.add('visible');
+function showLastWeightInfo(exerciseId) {
+    if (exerciseId && exerciseLastWeights[exerciseId]) {
+        var entry = exerciseLastWeights[exerciseId];
+        lastWeightInfoEl.innerHTML = "Last: " + entry.weight + " kg @ " + entry.date +
+            ' <button type="button" class="btn btn-sm btn-inline" style="background:var(--gold);color:var(--text-inverse);border-color:var(--gold);" onclick="fillLastWeight()">Fill</button>';
+        lastWeightInfoEl.classList.add('visible');
     } else {
-        prInfoEl.innerHTML = "";
-        prInfoEl.classList.remove('visible');
+        lastWeightInfoEl.innerHTML = "";
+        lastWeightInfoEl.classList.remove('visible');
     }
 }
 
-function fillMaxWeight() {
+function fillLastWeight() {
     var exerciseId = exerciseSelect.value;
-    if (exerciseId && exercisePRs[exerciseId]) {
-        document.getElementById('weight').value = exercisePRs[exerciseId].weight;
+    if (exerciseId && exerciseLastWeights[exerciseId]) {
+        document.getElementById('weight').value = exerciseLastWeights[exerciseId].weight;
     }
 }
 
 exerciseSelect.addEventListener('change', function() {
-    showPRInfo(this.value);
+    showLastWeightInfo(this.value);
 });
 
 function cloneSet(exerciseId, weight, reps, rpe) {
@@ -164,7 +164,7 @@ function cloneSet(exerciseId, weight, reps, rpe) {
     } else {
         document.getElementById('rpe').value = '';
     }
-    showPRInfo(exerciseId);
+    showLastWeightInfo(exerciseId);
     exerciseSelect.scrollIntoView({ behavior: 'smooth' });
 }
 


### PR DESCRIPTION
## Summary
- Replace the "Max Weight" inline hint above the weight input on the workout detail page with a "Last" hint that surfaces the most recently logged weight for the selected exercise — more useful as a prefill for day-to-day logging than the all-time PR.
- Introduce `LastExerciseWeight` and `WorkoutRepository::get_last_weight_per_exercise_by_user` (uses `MAX(created_at)` per `exercise_id` to pick the latest row per group). Stats pages continue to use the existing `DynamicPR` / max queries unchanged.
- Rename the related JS helpers (`fillLastWeight`, `showLastWeightInfo`, `exerciseLastWeights`).
- Add regression tests asserting the latest log wins over the heaviest one, plus the empty case.

## Test plan
- [x] `cargo nextest run` — 262 passed
- [x] `cargo fmt --all -- --check` clean
- [ ] Manual: open a workout, pick an exercise that has logs in older sessions; confirm the inline hint shows "Last: <kg> @ <date>" using the most recent log (not the all-time max), and that "Fill" populates the weight input with that value