### PR TITLE
test(e2e): cover auth, workouts, sharing, settings

### DIFF
--- a/tests/e2e/features/auth/_bootstrap.feature
+++ b/tests/e2e/features/auth/_bootstrap.feature
@@ -1,0 +1,8 @@
+Feature: First-time setup
+
+  On a fresh install the login route should funnel the very first user
+  into account creation rather than presenting a login form.
+
+  Scenario: /auth/login redirects to setup when no users exist
+    When I visit "/auth/login"
+    Then I see the setup page

--- a/tests/e2e/features/auth/login.feature
+++ b/tests/e2e/features/auth/login.feature
@@ -7,3 +7,9 @@ Feature: Logging in
     Given a user "lifter" with password "barbell-club" exists
     When I log in as "lifter" with password "barbell-club"
     Then I see the dashboard
+
+  Scenario: Logging in with the wrong password shows an error
+    Given a user "lifter" with password "barbell-club" exists
+    When I log in as "lifter" with password "definitely-not-it"
+    Then I see the login error "Invalid username or password"
+    And the URL is "/auth/login"

--- a/tests/e2e/features/auth/session.feature
+++ b/tests/e2e/features/auth/session.feature
@@ -1,0 +1,15 @@
+Feature: Session behaviour
+
+  Locks how the app routes around an authenticated session: the login
+  page must not show to someone who already has a session, and signing
+  out must drop them back to it.
+
+  Scenario: An already-logged-in user visiting the login page is sent home
+    Given I am logged in as "lifter"
+    When I visit "/auth/login"
+    Then I see the dashboard
+
+  Scenario: Signing out drops me back at the login page
+    Given I am logged in as "lifter"
+    When I log out
+    Then I see the login page

--- a/tests/e2e/features/exercises/create.feature
+++ b/tests/e2e/features/exercises/create.feature
@@ -1,0 +1,6 @@
+Feature: Managing exercises
+
+  Scenario: A newly created exercise appears on the exercises page
+    Given I am logged in as "lifter"
+    When I create a new exercise in category "legs"
+    Then the exercise I created is listed on the exercises page

--- a/tests/e2e/features/settings/change_password.feature
+++ b/tests/e2e/features/settings/change_password.feature
@@ -1,0 +1,10 @@
+Feature: Changing my password
+
+  Scenario: After changing my password I can log in with the new one
+    Given a user "pwchange" with password "originalpass" exists
+    And I am logged in as "pwchange" with password "originalpass"
+    When I change my password from "originalpass" to "newP4ssw0rd"
+    Then I see a password-change success message
+    When I log out
+    And I log in as "pwchange" with password "newP4ssw0rd"
+    Then I see the dashboard

--- a/tests/e2e/features/sharing/sharing.feature
+++ b/tests/e2e/features/sharing/sharing.feature
@@ -1,0 +1,19 @@
+Feature: Sharing a workout
+
+  Background:
+    Given I am logged in as "lifter"
+    And I have an exercise in category "back"
+    And I have a workout with a set of 80 kg for 5 reps
+
+  Scenario: Sharing a workout exposes a public link
+    When I share the workout
+    Then a public share link is shown on the workout page
+
+  Scenario: A guest can open the share URL without logging in
+    Given I have shared the workout
+    Then a guest can view the workout via the share URL
+
+  Scenario: Revoking a share makes the URL 404 for guests
+    Given I have shared the workout
+    When I revoke the share
+    Then a guest visiting the share URL gets a 404

--- a/tests/e2e/features/workouts/lifecycle.feature
+++ b/tests/e2e/features/workouts/lifecycle.feature
@@ -1,0 +1,30 @@
+Feature: Workout lifecycle
+
+  The core training journal: start a session, log a set, fix a set,
+  remove the session.
+
+  Scenario: Starting a workout puts it on the workouts list
+    Given I am logged in as "lifter"
+    When I start a new workout for today
+    Then I am on the workout detail page
+    And the workout I created is listed on the workouts page
+
+  Scenario: Logging a set into a workout shows it on the detail page
+    Given I am logged in as "lifter"
+    And I have an exercise in category "chest"
+    And I have a workout
+    When I log a set of 100 kg for 5 reps using the exercise I created
+    Then I see my set logged at 100 kg for 5 reps
+
+  Scenario: Editing a set updates the weight and reps
+    Given I am logged in as "lifter"
+    And I have an exercise in category "shoulders"
+    And I have a workout with a set of 50 kg for 8 reps
+    When I edit my set to 60 kg for 6 reps
+    Then I see my set logged at 60 kg for 6 reps
+
+  Scenario: Deleting a workout removes it from the list
+    Given I am logged in as "lifter"
+    And I have a workout
+    When I delete the workout
+    Then the workout I deleted is not listed on the workouts page

--- a/tests/e2e/steps/auth.steps.js
+++ b/tests/e2e/steps/auth.steps.js
@@ -1,40 +1,75 @@
 import { expect } from '@playwright/test';
 import { createBdd } from 'playwright-bdd';
 import { test } from './fixtures.js';
+import { ADMIN, ensureUser } from '../support/seeding.js';
 
 const { Given, When, Then } = createBdd(test);
 
-// The Rust server boots with an empty sqlite DB per run, so /auth/setup is
-// the only path that can create the first user. Subsequent calls 302 back to
-// /auth/login, which is treated as a no-op here.
+async function loginViaUi(page, username, password) {
+  await page.goto('/auth/login');
+  await page.getByLabel('Username').fill(username);
+  await page.getByLabel('Password').fill(password);
+  await page.getByRole('button', { name: 'Login' }).click();
+}
+
 Given(
   'a user {string} with password {string} exists',
   async ({ request, baseURL }, username, password) => {
-    const res = await request.post(`${baseURL}/auth/setup`, {
-      form: { username, password },
-      maxRedirects: 0,
-      failOnStatusCode: false,
-    });
-    expect(
-      [200, 302, 303],
-      `unexpected /auth/setup status ${res.status()}`,
-    ).toContain(res.status());
+    await ensureUser(request, baseURL, username, password);
+  },
+);
+
+Given('I am logged in as {string}', async ({ page, request, baseURL }, username) => {
+  await ensureUser(request, baseURL, username, ADMIN.password);
+  await loginViaUi(page, username, ADMIN.password);
+  await expect(
+    page.getByRole('heading', { name: 'Dashboard', level: 1 }),
+  ).toBeVisible();
+});
+
+Given(
+  'I am logged in as {string} with password {string}',
+  async ({ page, request, baseURL }, username, password) => {
+    await ensureUser(request, baseURL, username, password);
+    await loginViaUi(page, username, password);
+    await expect(
+      page.getByRole('heading', { name: 'Dashboard', level: 1 }),
+    ).toBeVisible();
   },
 );
 
 When(
   'I log in as {string} with password {string}',
   async ({ page }, username, password) => {
-    await page.goto('/auth/login');
-    await page.getByLabel('Username').fill(username);
-    await page.getByLabel('Password').fill(password);
-    await page.getByRole('button', { name: 'Login' }).click();
+    await loginViaUi(page, username, password);
   },
 );
+
+When('I log out', async ({ page }) => {
+  await page.getByRole('button', { name: 'Sign Out' }).click();
+});
 
 Then('I see the dashboard', async ({ page }) => {
   await expect(page).toHaveURL('/');
   await expect(
     page.getByRole('heading', { name: 'Dashboard', level: 1 }),
   ).toBeVisible();
+});
+
+Then('I see the login page', async ({ page }) => {
+  await expect(page).toHaveURL('/auth/login');
+  await expect(
+    page.getByRole('button', { name: 'Login' }),
+  ).toBeVisible();
+});
+
+Then('I see the setup page', async ({ page }) => {
+  await expect(page).toHaveURL('/auth/setup');
+  await expect(
+    page.getByRole('button', { name: 'Create Account' }),
+  ).toBeVisible();
+});
+
+Then('I see the login error {string}', async ({ page }, message) => {
+  await expect(page.locator('.error')).toContainText(message);
 });

--- a/tests/e2e/steps/common.steps.js
+++ b/tests/e2e/steps/common.steps.js
@@ -1,0 +1,13 @@
+import { expect } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+import { test } from './fixtures.js';
+
+const { When, Then } = createBdd(test);
+
+When('I visit {string}', async ({ page }, path) => {
+  await page.goto(path);
+});
+
+Then('the URL is {string}', async ({ page }, path) => {
+  await expect(page).toHaveURL(path);
+});

--- a/tests/e2e/steps/exercises.steps.js
+++ b/tests/e2e/steps/exercises.steps.js
@@ -1,0 +1,41 @@
+import { expect } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+import { test } from './fixtures.js';
+
+const { Given, When, Then } = createBdd(test);
+
+async function createExercise(page, name, category) {
+  await page.goto('/exercises/new');
+  await page.getByLabel('Name').fill(name);
+  await page.getByLabel('Category').selectOption(category);
+  await page.getByRole('button', { name: 'Add Exercise' }).click();
+  await expect(page).toHaveURL('/exercises');
+}
+
+When(
+  'I create a new exercise in category {string}',
+  async ({ page, scenarioState }, category) => {
+    const name = scenarioState.unique('Squat');
+    await createExercise(page, name, category);
+    scenarioState.exerciseName = name;
+  },
+);
+
+Given(
+  'I have an exercise in category {string}',
+  async ({ page, scenarioState }, category) => {
+    const name = scenarioState.unique('Exercise');
+    await createExercise(page, name, category);
+    scenarioState.exerciseName = name;
+  },
+);
+
+Then(
+  'the exercise I created is listed on the exercises page',
+  async ({ page, scenarioState }) => {
+    await page.goto('/exercises');
+    await expect(
+      page.getByRole('link', { name: scenarioState.exerciseName }),
+    ).toBeVisible();
+  },
+);

--- a/tests/e2e/steps/fixtures.js
+++ b/tests/e2e/steps/fixtures.js
@@ -1,11 +1,24 @@
 import { test as base } from 'playwright-bdd';
+import { randomBytes } from 'node:crypto';
 
-// Every scenario starts logged-out. Cookies wouldn't normally persist across
-// scenarios anyway (a fresh browser context is created), but being explicit
-// keeps the contract obvious.
+// Each scenario gets a freshly-cleared browser context plus a scratch state
+// object scoped to that scenario. We share one sqlite DB across the whole
+// run, so steps must use `state.suffix` to scope created entities and assert
+// only on what this scenario built.
 export const test = base.extend({
   context: async ({ context }, use) => {
     await context.clearCookies();
     await use(context);
+  },
+  scenarioState: async ({}, use) => {
+    const suffix = randomBytes(4).toString('hex');
+    await use({
+      suffix,
+      unique: (prefix) => `${prefix}-${suffix}`,
+      workoutId: null,
+      exerciseId: null,
+      exerciseName: null,
+      shareUrl: null,
+    });
   },
 });

--- a/tests/e2e/steps/settings.steps.js
+++ b/tests/e2e/steps/settings.steps.js
@@ -1,0 +1,22 @@
+import { expect } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+import { test } from './fixtures.js';
+
+const { When, Then } = createBdd(test);
+
+When(
+  'I change my password from {string} to {string}',
+  async ({ page }, currentPassword, newPassword) => {
+    await page.goto('/settings');
+    await page.getByLabel('Current Password').fill(currentPassword);
+    await page.getByLabel('New Password', { exact: true }).fill(newPassword);
+    await page.getByLabel('Confirm New Password').fill(newPassword);
+    await page.getByRole('button', { name: 'Change Password' }).click();
+  },
+);
+
+Then('I see a password-change success message', async ({ page }) => {
+  await expect(page.locator('.alert-success')).toContainText(
+    'Password changed successfully',
+  );
+});

--- a/tests/e2e/steps/sharing.steps.js
+++ b/tests/e2e/steps/sharing.steps.js
@@ -1,0 +1,73 @@
+import { expect } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+import { test } from './fixtures.js';
+
+const { Given, When, Then } = createBdd(test);
+
+async function shareCurrentWorkout(page, scenarioState) {
+  await page.goto(`/workouts/${scenarioState.workoutId}`);
+  await page
+    .locator('form[action$="/share"]')
+    .getByRole('button', { name: 'Share' })
+    .click();
+  const link = page.locator('.share-info a');
+  await expect(link).toBeVisible();
+  scenarioState.shareUrl = await link.getAttribute('href');
+}
+
+When('I share the workout', async ({ page, scenarioState }) => {
+  await shareCurrentWorkout(page, scenarioState);
+});
+
+Given('I have shared the workout', async ({ page, scenarioState }) => {
+  await shareCurrentWorkout(page, scenarioState);
+});
+
+When('I revoke the share', async ({ page, scenarioState }) => {
+  await page.goto(`/workouts/${scenarioState.workoutId}`);
+  page.once('dialog', (d) => d.accept());
+  await page.getByRole('button', { name: 'Revoke Share' }).click();
+  await expect(page.locator('.share-info')).toHaveCount(0);
+});
+
+Then(
+  'a public share link is shown on the workout page',
+  async ({ page, scenarioState }) => {
+    await page.goto(`/workouts/${scenarioState.workoutId}`);
+    const link = page.locator('.share-info a');
+    await expect(link).toBeVisible();
+    expect(scenarioState.shareUrl).toMatch(/^\/shared\/[A-Za-z0-9_-]+$/);
+  },
+);
+
+Then(
+  'a guest can view the workout via the share URL',
+  async ({ browser, scenarioState }) => {
+    const guest = await browser.newContext();
+    try {
+      const guestPage = await guest.newPage();
+      const response = await guestPage.goto(scenarioState.shareUrl);
+      expect(response?.status()).toBe(200);
+      await expect(
+        guestPage.locator('.subtitle').first(),
+      ).toContainText('Shared by');
+      await expect(guestPage.locator('.set-row').first()).toBeVisible();
+    } finally {
+      await guest.close();
+    }
+  },
+);
+
+Then(
+  'a guest visiting the share URL gets a 404',
+  async ({ browser, scenarioState }) => {
+    const guest = await browser.newContext();
+    try {
+      const guestPage = await guest.newPage();
+      const response = await guestPage.goto(scenarioState.shareUrl);
+      expect(response?.status()).toBe(404);
+    } finally {
+      await guest.close();
+    }
+  },
+);

--- a/tests/e2e/steps/workouts.steps.js
+++ b/tests/e2e/steps/workouts.steps.js
@@ -1,0 +1,126 @@
+import { expect } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+import { test } from './fixtures.js';
+
+const { Given, When, Then } = createBdd(test);
+
+function workoutIdFromUrl(page) {
+  const match = new URL(page.url()).pathname.match(/^\/workouts\/([0-9a-f-]+)/i);
+  if (!match) throw new Error(`not on a workout detail page: ${page.url()}`);
+  return match[1];
+}
+
+async function createTodaysWorkout(page, scenarioState) {
+  await page.goto('/workouts/new');
+  await page.getByRole('button', { name: 'Create Workout' }).click();
+  await expect(page).toHaveURL(/^.*\/workouts\/[0-9a-f-]+$/i);
+  scenarioState.workoutId = workoutIdFromUrl(page);
+}
+
+async function logSet(page, exerciseName, weight, reps) {
+  await page
+    .locator('select#exercise_id')
+    .selectOption({ label: exerciseName });
+  await page.getByLabel('Weight').fill(String(weight));
+  await page.getByLabel('Reps').fill(String(reps));
+  await page.getByRole('button', { name: 'Add Set' }).click();
+  // The form posts and re-renders /workouts/{id}; wait for the new row.
+  await expect(
+    page.locator('.set-row').filter({ hasText: exerciseName }).first(),
+  ).toBeVisible();
+}
+
+When('I start a new workout for today', async ({ page, scenarioState }) => {
+  await createTodaysWorkout(page, scenarioState);
+});
+
+Given('I have a workout', async ({ page, scenarioState }) => {
+  await createTodaysWorkout(page, scenarioState);
+});
+
+When(
+  'I log a set of {int} kg for {int} reps using the exercise I created',
+  async ({ page, scenarioState }, weight, reps) => {
+    await page.goto(`/workouts/${scenarioState.workoutId}`);
+    await logSet(page, scenarioState.exerciseName, weight, reps);
+  },
+);
+
+Given(
+  'I have a workout with a set of {int} kg for {int} reps',
+  async ({ page, scenarioState }, weight, reps) => {
+    if (!scenarioState.exerciseName) {
+      throw new Error('this step requires an exercise to exist first');
+    }
+    await createTodaysWorkout(page, scenarioState);
+    await logSet(page, scenarioState.exerciseName, weight, reps);
+  },
+);
+
+When(
+  'I edit my set to {int} kg for {int} reps',
+  async ({ page, scenarioState }, weight, reps) => {
+    await page.goto(`/workouts/${scenarioState.workoutId}`);
+    const row = page
+      .locator('.set-row')
+      .filter({ hasText: scenarioState.exerciseName })
+      .first();
+    await row.getByRole('link', { name: 'Edit' }).click();
+    await expect(
+      page.getByRole('heading', { name: 'Edit Set', level: 1 }),
+    ).toBeVisible();
+    await page.getByLabel('Weight').fill(String(weight));
+    await page.getByLabel('Reps').fill(String(reps));
+    await page.getByRole('button', { name: 'Save Changes' }).click();
+    await expect(page).toHaveURL(`/workouts/${scenarioState.workoutId}`);
+  },
+);
+
+When('I delete the workout', async ({ page, scenarioState }) => {
+  await page.goto(`/workouts/${scenarioState.workoutId}`);
+  page.once('dialog', (d) => d.accept());
+  await page
+    .locator('form[action$="/delete"]')
+    .filter({ has: page.getByRole('button', { name: 'Delete' }) })
+    .first()
+    .getByRole('button', { name: 'Delete' })
+    .click();
+  await expect(page).toHaveURL('/workouts');
+});
+
+Then('I am on the workout detail page', async ({ page, scenarioState }) => {
+  expect(workoutIdFromUrl(page)).toBe(scenarioState.workoutId);
+});
+
+Then(
+  'the workout I created is listed on the workouts page',
+  async ({ page, scenarioState }) => {
+    await page.goto('/workouts');
+    await expect(
+      page.locator(`a[href="/workouts/${scenarioState.workoutId}"]`),
+    ).toBeVisible();
+  },
+);
+
+Then(
+  'the workout I deleted is not listed on the workouts page',
+  async ({ page, scenarioState }) => {
+    await page.goto('/workouts');
+    await expect(
+      page.locator(`a[href="/workouts/${scenarioState.workoutId}"]`),
+    ).toHaveCount(0);
+  },
+);
+
+Then(
+  'I see my set logged at {int} kg for {int} reps',
+  async ({ page, scenarioState }, weight, reps) => {
+    await page.goto(`/workouts/${scenarioState.workoutId}`);
+    const row = page
+      .locator('.set-row')
+      .filter({ hasText: scenarioState.exerciseName })
+      .first();
+    await expect(row.locator('.set-cell-weight')).toHaveText(String(weight));
+    await expect(row.locator('.set-cell-reps')).toHaveText(String(reps));
+  },
+);

--- a/tests/e2e/support/seeding.js
+++ b/tests/e2e/support/seeding.js
@@ -1,0 +1,49 @@
+import { expect } from '@playwright/test';
+
+export const ADMIN = { username: 'lifter', password: 'barbell-club' };
+
+const STATUS_OK_OR_REDIRECT = [200, 302, 303];
+
+// /auth/setup creates the first user (admin). It's idempotent for our needs:
+// re-running 302s to /auth/login because user_count > 0.
+async function callSetup(request, baseURL, { username, password }) {
+  const res = await request.post(`${baseURL}/auth/setup`, {
+    form: { username, password },
+    maxRedirects: 0,
+    failOnStatusCode: false,
+  });
+  expect(
+    STATUS_OK_OR_REDIRECT,
+    `/auth/setup unexpected status ${res.status()}`,
+  ).toContain(res.status());
+}
+
+async function adminLogin(request, baseURL) {
+  const res = await request.post(`${baseURL}/auth/login`, {
+    form: ADMIN,
+    maxRedirects: 0,
+    failOnStatusCode: false,
+  });
+  expect(
+    [302, 303],
+    `admin login expected redirect, got ${res.status()}`,
+  ).toContain(res.status());
+}
+
+// Make sure the named user exists. The first user (admin) is created via
+// /auth/setup; everyone else is created by the admin through /users/new.
+// Idempotent: if a user with the same name already exists the create endpoint
+// renders the same page with an error, which we ignore.
+export async function ensureUser(request, baseURL, username, password) {
+  if (username === ADMIN.username) {
+    await callSetup(request, baseURL, ADMIN);
+    return;
+  }
+  await callSetup(request, baseURL, ADMIN);
+  await adminLogin(request, baseURL);
+  await request.post(`${baseURL}/users/new`, {
+    form: { username, password },
+    maxRedirects: 0,
+    failOnStatusCode: false,
+  });
+}


### PR DESCRIPTION
## Summary

Takes the UI BDD suite from 1 scenario to 14. The goal is a behavioural safety net so UI redesigns can't silently break user-facing flows.

New scenarios:

| Area | Scenario |
|---|---|
| bootstrap | empty DB redirects `/auth/login` to `/auth/setup` |
| login | wrong password shows error, stays on `/auth/login` |
| session | already-logged-in user visiting `/auth/login` is sent home |
| session | sign-out drops back to login page |
| exercises | newly created exercise is listed |
| workouts | start workout puts it on list |
| workouts | log a set, see it on detail page |
| workouts | edit a set, see updated values |
| workouts | delete a workout, gone from list |
| sharing | share button exposes a public link |
| sharing | guest can view via the share URL |
| sharing | revoking a share makes the URL 404 |
| settings | change password and re-login with the new one |

## Notes

- A new ``scenarioState`` fixture assigns each scenario a random suffix; steps use it to create uniquely-named entities and assert only on what they themselves built. The whole run still shares one sqlite DB.
- ``support/seeding.js`` keeps user creation idempotent: the first user is seeded via ``/auth/setup``, additional users via admin-driven ``/users/new``.
- Confirmation dialogs (delete workout, revoke share) are accepted with ``page.once('dialog', ...)``.
- Guest-view scenarios use ``browser.newContext()`` so the logged-in cookie can't leak into the public render path.
- ``_bootstrap.feature`` is named so it sorts first; it relies on the run starting with an empty DB.

## Test plan

- [ ] ``cd tests/e2e && npm test`` — expect 14 scenarios passing
- [ ] CI ``e2e`` job remains green
- [ ] Sanity-check the HTML report when CI uploads it

🤖 Generated with [Claude Code](https://claude.com/claude-code)