### PR TITLE
test(e2e): cover validation, RBAC, auth wall, more lifecycle

### DIFF
--- a/tests/e2e/features/auth/_bootstrap.feature
+++ b/tests/e2e/features/auth/_bootstrap.feature
@@ -1,8 +1,13 @@
 Feature: First-time setup
 
   On a fresh install the login route should funnel the very first user
-  into account creation rather than presenting a login form.
+  into account creation, and the setup form should refuse weak
+  passwords rather than silently creating an insecure admin.
 
   Scenario: /auth/login redirects to setup when no users exist
     When I visit "/auth/login"
     Then I see the setup page
+
+  Scenario: Setup rejects passwords shorter than 6 characters
+    When I submit the setup form with username "tiny" and password "abc"
+    Then I see the setup error "Password must be at least 6 characters"

--- a/tests/e2e/features/auth/guards.feature
+++ b/tests/e2e/features/auth/guards.feature
@@ -1,0 +1,15 @@
+Feature: Authentication wall
+
+  Unauthenticated visitors to private routes must be sent to the login
+  page rather than seeing partial UI or errors.
+
+  Background:
+    Given a user "lifter" with password "barbell-club" exists
+
+  Scenario: /workouts redirects to login when not authenticated
+    When I visit "/workouts"
+    Then I see the login page
+
+  Scenario: /settings redirects to login when not authenticated
+    When I visit "/settings"
+    Then I see the login page

--- a/tests/e2e/features/exercises/manage.feature
+++ b/tests/e2e/features/exercises/manage.feature
@@ -1,0 +1,13 @@
+Feature: Editing and deleting exercises
+
+  Scenario: Renaming an exercise updates its entry on the list
+    Given I am logged in as "lifter"
+    And I have an exercise in category "back"
+    When I rename my exercise
+    Then the exercise I created is listed on the exercises page
+
+  Scenario: Deleting an exercise removes it from the list
+    Given I am logged in as "lifter"
+    And I have an exercise in category "arms"
+    When I delete my exercise
+    Then my exercise is no longer listed on the exercises page

--- a/tests/e2e/features/settings/change_password.feature
+++ b/tests/e2e/features/settings/change_password.feature
@@ -1,5 +1,23 @@
 Feature: Changing my password
 
+  Scenario: Mismatched new password is rejected
+    Given a user "pwmismatch" with password "originalpass" exists
+    And I am logged in as "pwmismatch" with password "originalpass"
+    When I submit the password form with current "originalpass", new "newP4ssw0rd", confirm "oopsdifferent"
+    Then I see a settings error "New passwords do not match"
+
+  Scenario: Wrong current password is rejected
+    Given a user "pwwrong" with password "originalpass" exists
+    And I am logged in as "pwwrong" with password "originalpass"
+    When I submit the password form with current "wrongguess", new "newP4ssw0rd", confirm "newP4ssw0rd"
+    Then I see a settings error "Current password is incorrect"
+
+  Scenario: New password shorter than 6 characters is rejected
+    Given a user "pwshort" with password "originalpass" exists
+    And I am logged in as "pwshort" with password "originalpass"
+    When I submit the password form with current "originalpass", new "abc", confirm "abc"
+    Then I see a settings error "New password must be at least 6 characters"
+
   Scenario: After changing my password I can log in with the new one
     Given a user "pwchange" with password "originalpass" exists
     And I am logged in as "pwchange" with password "originalpass"

--- a/tests/e2e/features/users/admin.feature
+++ b/tests/e2e/features/users/admin.feature
@@ -1,0 +1,27 @@
+Feature: Admin user management
+
+  Locks the admin-only flows on /users: create, promote, delete, and
+  the negative path that hides those controls (and refuses the admin
+  endpoints) for non-admins.
+
+  Scenario: Admin can create a member user from the UI
+    Given I am logged in as "lifter"
+    When I create a new user via the admin UI
+    Then I see that user listed on the users page
+
+  Scenario: Admin promotes another user to admin
+    Given I am logged in as "lifter"
+    And another user exists
+    When I promote that user to admin
+    Then I see that user listed as Admin
+
+  Scenario: Admin deletes a user from the list
+    Given I am logged in as "lifter"
+    And another user exists
+    When I delete that user
+    Then I do not see that user on the users page
+
+  Scenario: Non-admin cannot reach admin-only user actions
+    Given I am logged in as a fresh non-admin user
+    Then I do not see the "+ Add New User" button on the users page
+    And visiting "/users/new" returns a 403

--- a/tests/e2e/features/workouts/lifecycle.feature
+++ b/tests/e2e/features/workouts/lifecycle.feature
@@ -1,7 +1,7 @@
 Feature: Workout lifecycle
 
   The core training journal: start a session, log a set, fix a set,
-  remove the session.
+  remove a set or the whole session, and edit the session metadata.
 
   Scenario: Starting a workout puts it on the workouts list
     Given I am logged in as "lifter"
@@ -22,6 +22,20 @@ Feature: Workout lifecycle
     And I have a workout with a set of 50 kg for 8 reps
     When I edit my set to 60 kg for 6 reps
     Then I see my set logged at 60 kg for 6 reps
+
+  Scenario: Deleting a single set leaves the workout intact
+    Given I am logged in as "lifter"
+    And I have an exercise in category "arms"
+    And I have a workout with a set of 20 kg for 12 reps
+    When I delete my set
+    Then my set is no longer shown on the workout
+    And I am on the workout detail page
+
+  Scenario: Editing a workout updates its date and notes
+    Given I am logged in as "lifter"
+    And I have a workout
+    When I edit the workout to date "2024-03-14" with notes "Heavy day"
+    Then the workout detail shows date "2024-03-14" and notes "Heavy day"
 
   Scenario: Deleting a workout removes it from the list
     Given I am logged in as "lifter"

--- a/tests/e2e/features/workouts/pr_badge.feature
+++ b/tests/e2e/features/workouts/pr_badge.feature
@@ -1,0 +1,11 @@
+Feature: Personal record badges
+
+  Locks the automatic PR detection: a logged set on a fresh exercise
+  must come back from the server tagged as a personal record.
+
+  Scenario: The first set ever logged on an exercise is flagged as a PR
+    Given I am logged in as "lifter"
+    And I have an exercise in category "legs"
+    And I have a workout
+    When I log a set of 100 kg for 5 reps using the exercise I created
+    Then my set is flagged as a PR

--- a/tests/e2e/steps/auth.steps.js
+++ b/tests/e2e/steps/auth.steps.js
@@ -73,3 +73,37 @@ Then('I see the setup page', async ({ page }) => {
 Then('I see the login error {string}', async ({ page }, message) => {
   await expect(page.locator('.error')).toContainText(message);
 });
+
+When(
+  'I submit the setup form with username {string} and password {string}',
+  async ({ page }, username, password) => {
+    await page.goto('/auth/setup');
+    // Bypass the browser's own minlength/required validation so the
+    // request actually hits the server. We want to lock the server-side
+    // defense-in-depth check, not the HTML attributes.
+    await page.locator('form').evaluate((f) => {
+      f.noValidate = true;
+    });
+    await page.getByLabel('Username').fill(username);
+    await page.locator('#password').fill(password);
+    await page.getByRole('button', { name: 'Create Account' }).click();
+  },
+);
+
+Then('I see the setup error {string}', async ({ page }, message) => {
+  await expect(page).toHaveURL('/auth/setup');
+  await expect(page.locator('.error')).toContainText(message);
+});
+
+Given(
+  'I am logged in as a fresh non-admin user',
+  async ({ page, request, baseURL, scenarioState }) => {
+    const username = scenarioState.unique('member');
+    scenarioState.currentUser = username;
+    await ensureUser(request, baseURL, username, ADMIN.password);
+    await loginViaUi(page, username, ADMIN.password);
+    await expect(
+      page.getByRole('heading', { name: 'Dashboard', level: 1 }),
+    ).toBeVisible();
+  },
+);

--- a/tests/e2e/steps/exercises.steps.js
+++ b/tests/e2e/steps/exercises.steps.js
@@ -39,3 +39,44 @@ Then(
     ).toBeVisible();
   },
 );
+
+When(
+  'I rename my exercise',
+  async ({ page, scenarioState }) => {
+    await page.goto('/exercises');
+    const row = page
+      .locator('.exercise-item')
+      .filter({
+        has: page.getByRole('link', { name: scenarioState.exerciseName }),
+      })
+      .first();
+    await row.getByRole('link', { name: 'Edit' }).click();
+    const newName = scenarioState.unique('Renamed');
+    await page.getByLabel('Name').fill(newName);
+    await page.getByRole('button', { name: 'Save Changes' }).click();
+    await expect(page).toHaveURL('/exercises');
+    scenarioState.exerciseName = newName;
+  },
+);
+
+When('I delete my exercise', async ({ page, scenarioState }) => {
+  await page.goto('/exercises');
+  const row = page
+    .locator('.exercise-item')
+    .filter({
+      has: page.getByRole('link', { name: scenarioState.exerciseName }),
+    })
+    .first();
+  page.once('dialog', (d) => d.accept());
+  await row.getByRole('button', { name: 'Delete' }).click();
+});
+
+Then(
+  'my exercise is no longer listed on the exercises page',
+  async ({ page, scenarioState }) => {
+    await page.goto('/exercises');
+    await expect(
+      page.getByRole('link', { name: scenarioState.exerciseName }),
+    ).toHaveCount(0);
+  },
+);

--- a/tests/e2e/steps/settings.steps.js
+++ b/tests/e2e/steps/settings.steps.js
@@ -4,14 +4,25 @@ import { test } from './fixtures.js';
 
 const { When, Then } = createBdd(test);
 
+async function fillPasswordForm(page, current, next, confirm) {
+  await page.goto('/settings');
+  await page.getByLabel('Current Password').fill(current);
+  await page.getByLabel('New Password', { exact: true }).fill(next);
+  await page.getByLabel('Confirm New Password').fill(confirm);
+  await page.getByRole('button', { name: 'Change Password' }).click();
+}
+
 When(
   'I change my password from {string} to {string}',
-  async ({ page }, currentPassword, newPassword) => {
-    await page.goto('/settings');
-    await page.getByLabel('Current Password').fill(currentPassword);
-    await page.getByLabel('New Password', { exact: true }).fill(newPassword);
-    await page.getByLabel('Confirm New Password').fill(newPassword);
-    await page.getByRole('button', { name: 'Change Password' }).click();
+  async ({ page }, current, next) => {
+    await fillPasswordForm(page, current, next, next);
+  },
+);
+
+When(
+  'I submit the password form with current {string}, new {string}, confirm {string}',
+  async ({ page }, current, next, confirm) => {
+    await fillPasswordForm(page, current, next, confirm);
   },
 );
 
@@ -19,4 +30,8 @@ Then('I see a password-change success message', async ({ page }) => {
   await expect(page.locator('.alert-success')).toContainText(
     'Password changed successfully',
   );
+});
+
+Then('I see a settings error {string}', async ({ page }, message) => {
+  await expect(page.locator('.error')).toContainText(message);
 });

--- a/tests/e2e/steps/users.steps.js
+++ b/tests/e2e/steps/users.steps.js
@@ -1,0 +1,88 @@
+import { expect } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+import { test } from './fixtures.js';
+import { ADMIN, ensureUser } from '../support/seeding.js';
+
+const { Given, When, Then } = createBdd(test);
+
+function userRow(page, username) {
+  return page.locator('tr').filter({ hasText: username }).first();
+}
+
+Given(
+  'another user exists',
+  async ({ request, baseURL, scenarioState }) => {
+    const username = scenarioState.unique('subject');
+    scenarioState.otherUser = username;
+    await ensureUser(request, baseURL, username, ADMIN.password);
+  },
+);
+
+When(
+  'I create a new user via the admin UI',
+  async ({ page, scenarioState }) => {
+    const username = scenarioState.unique('newbie');
+    scenarioState.otherUser = username;
+    await page.goto('/users/new');
+    await page.getByLabel('Username').fill(username);
+    await page.locator('#password').fill('starting-pass');
+    await page.getByRole('button', { name: 'Create User' }).click();
+    await expect(page).toHaveURL('/users');
+  },
+);
+
+When('I promote that user to admin', async ({ page, scenarioState }) => {
+  await page.goto('/users');
+  page.once('dialog', (d) => d.accept());
+  await userRow(page, scenarioState.otherUser)
+    .getByRole('button', { name: 'Promote' })
+    .click();
+  await expect(page).toHaveURL('/users');
+});
+
+When('I delete that user', async ({ page, scenarioState }) => {
+  await page.goto('/users');
+  page.once('dialog', (d) => d.accept());
+  await userRow(page, scenarioState.otherUser)
+    .getByRole('button', { name: 'Delete' })
+    .click();
+  await expect(page).toHaveURL('/users');
+});
+
+Then(
+  'I see that user listed on the users page',
+  async ({ page, scenarioState }) => {
+    await page.goto('/users');
+    await expect(userRow(page, scenarioState.otherUser)).toBeVisible();
+  },
+);
+
+Then('I see that user listed as Admin', async ({ page, scenarioState }) => {
+  await page.goto('/users');
+  await expect(userRow(page, scenarioState.otherUser)).toContainText('admin');
+});
+
+Then(
+  'I do not see that user on the users page',
+  async ({ page, scenarioState }) => {
+    await page.goto('/users');
+    await expect(
+      page.locator('tr').filter({ hasText: scenarioState.otherUser }),
+    ).toHaveCount(0);
+  },
+);
+
+Then(
+  'I do not see the {string} button on the users page',
+  async ({ page }, name) => {
+    await page.goto('/users');
+    await expect(
+      page.getByRole('link', { name }),
+    ).toHaveCount(0);
+  },
+);
+
+Then('visiting {string} returns a 403', async ({ page }, path) => {
+  const response = await page.goto(path);
+  expect(response?.status()).toBe(403);
+});

--- a/tests/e2e/steps/workouts.steps.js
+++ b/tests/e2e/steps/workouts.steps.js
@@ -124,3 +124,54 @@ Then(
     await expect(row.locator('.set-cell-reps')).toHaveText(String(reps));
   },
 );
+
+When('I delete my set', async ({ page, scenarioState }) => {
+  await page.goto(`/workouts/${scenarioState.workoutId}`);
+  const row = page
+    .locator('.set-row')
+    .filter({ hasText: scenarioState.exerciseName })
+    .first();
+  page.once('dialog', (d) => d.accept());
+  await row.locator('form[action*="/logs/"][action$="/delete"] button').click();
+});
+
+Then(
+  'my set is no longer shown on the workout',
+  async ({ page, scenarioState }) => {
+    await page.goto(`/workouts/${scenarioState.workoutId}`);
+    await expect(
+      page.locator('.set-row').filter({ hasText: scenarioState.exerciseName }),
+    ).toHaveCount(0);
+  },
+);
+
+When(
+  'I edit the workout to date {string} with notes {string}',
+  async ({ page, scenarioState }, date, notes) => {
+    await page.goto(`/workouts/${scenarioState.workoutId}/edit`);
+    await page.getByLabel('Date').fill(date);
+    await page.getByLabel('Notes (optional)').fill(notes);
+    await page.getByRole('button', { name: 'Save Changes' }).click();
+    await expect(page).toHaveURL(`/workouts/${scenarioState.workoutId}`);
+  },
+);
+
+Then(
+  'the workout detail shows date {string} and notes {string}',
+  async ({ page, scenarioState }, date, notes) => {
+    await page.goto(`/workouts/${scenarioState.workoutId}`);
+    await expect(
+      page.getByRole('heading', { level: 1, name: date }),
+    ).toBeVisible();
+    await expect(page.locator('.subtitle em')).toHaveText(notes);
+  },
+);
+
+Then('my set is flagged as a PR', async ({ page, scenarioState }) => {
+  await page.goto(`/workouts/${scenarioState.workoutId}`);
+  const row = page
+    .locator('.set-row')
+    .filter({ hasText: scenarioState.exerciseName })
+    .first();
+  await expect(row.locator('.pr-badge')).toBeVisible();
+});


### PR DESCRIPTION
## Summary

Adds 15 new scenarios, taking the BDD suite from 14 to 29. Focus is on regions that previously had no coverage: form validation gates, the auth wall, RBAC on /users, and the gaps in the workout/exercise lifecycle.

| Area | Scenarios |
|---|---|
| setup | reject password < 6 chars |
| change password | mismatch / wrong current / short new |
| auth wall | unauth ``/workouts`` and ``/settings`` redirect to login |
| workouts | delete single set; edit date + notes; first-ever set is flagged as PR |
| exercises | rename; delete |
| users (admin) | create / promote / delete a member |
| users (non-admin) | admin controls hidden + ``/users/new`` returns 403 |

## Notes

- **Bypassing browser-side validation.** The setup short-password scenario calls ``form.noValidate = true`` before submit so the request actually reaches the server. The intent is to pin the server-side check, not the ``minlength`` HTML attribute (those are defense in depth).
- **Auth wall feature is order-independent.** Its ``Background`` seeds the admin user, so it works whether it runs before or after the existing ``auth/login.feature``.
- **Per-scenario subject users.** ``users.steps.js`` introduces an *another user* pattern: each scenario generates its own username through ``scenarioState.unique`` so promote/delete don't collide across scenarios in the shared DB.

## Test plan

- [ ] ``cd tests/e2e && npm test`` — expect 29 scenarios passing
- [ ] CI ``e2e`` job remains green
- [ ] Spot check the HTML report when CI uploads it

🤖 Generated with [Claude Code](https://claude.com/claude-code)