### PR TITLE
test(e2e): cover stats, dashboard, sessions, cross-user, more

### DIFF
--- a/tests/e2e/features/dashboard/recent.feature
+++ b/tests/e2e/features/dashboard/recent.feature
@@ -1,0 +1,12 @@
+Feature: Dashboard summary
+
+  Scenario: A newly created workout appears in the dashboard's Recent Workouts
+    Given I am logged in as a fresh non-admin user
+    When I start a new workout for today
+    Then the dashboard lists the workout I created in Recent Workouts
+
+  Scenario: "This Week" count reflects a freshly logged workout
+    Given I am logged in as a fresh non-admin user
+    Then the dashboard "This Week" count is 0
+    When I start a new workout for today
+    Then the dashboard "This Week" count is 1

--- a/tests/e2e/features/settings/sessions.feature
+++ b/tests/e2e/features/settings/sessions.feature
@@ -1,0 +1,13 @@
+Feature: Active session management
+
+  Scenario: Logging out other devices leaves just this session
+    Given a user "logoutme" with password "barbell-club" exists
+    And I have a second session as "logoutme"
+    And I am logged in as "logoutme" with password "barbell-club"
+    Then the active sessions table has 2 rows
+    When I log out all other devices
+    Then the active sessions table has 1 row
+
+  Scenario: The current device is marked on the active sessions list
+    Given I am logged in as "lifter"
+    Then the active sessions table marks my current device

--- a/tests/e2e/features/stats/stats.feature
+++ b/tests/e2e/features/stats/stats.feature
@@ -1,0 +1,19 @@
+Feature: Stats pages
+
+  Scenario: /stats renders for a logged-in user
+    Given I am logged in as "lifter"
+    And I have a workout
+    Then I see the stats overview
+
+  Scenario: /stats/exercise/{id} renders for an exercise that has logs
+    Given I am logged in as "lifter"
+    And I have an exercise in category "back"
+    And I have a workout with a set of 60 kg for 5 reps
+    Then I see exercise-specific stats for the exercise I created
+
+  Scenario: /stats/prs lists the PR after logging a new set
+    Given I am logged in as "lifter"
+    And I have an exercise in category "legs"
+    And I have a workout
+    When I log a set of 100 kg for 5 reps using the exercise I created
+    Then the PR list shows my exercise

--- a/tests/e2e/features/users/admin.feature
+++ b/tests/e2e/features/users/admin.feature
@@ -25,3 +25,7 @@ Feature: Admin user management
     Given I am logged in as a fresh non-admin user
     Then I do not see the "+ Add New User" button on the users page
     And visiting "/users/new" returns a 403
+
+  Scenario: Admin cannot delete their own account from the users page
+    Given I am logged in as "lifter"
+    Then the users page does not let me delete my own account

--- a/tests/e2e/features/workouts/lifecycle.feature
+++ b/tests/e2e/features/workouts/lifecycle.feature
@@ -42,3 +42,24 @@ Feature: Workout lifecycle
     And I have a workout
     When I delete the workout
     Then the workout I deleted is not listed on the workouts page
+
+  Scenario: Logging a set with RPE persists the RPE value
+    Given I am logged in as "lifter"
+    And I have an exercise in category "chest"
+    And I have a workout
+    When I log a set of 100 kg for 5 reps with RPE 8 using the exercise I created
+    Then I see my set logged with RPE 8
+
+  Scenario: Multiple sets of the same exercise are auto-numbered
+    Given I am logged in as "lifter"
+    And I have an exercise in category "back"
+    And I have a workout with a set of 40 kg for 10 reps
+    When I log another set of 50 kg for 8 reps using the same exercise
+    Then I see two sets numbered 1 and 2
+
+  Scenario: Clone-set button pre-fills the Add Set form
+    Given I am logged in as "lifter"
+    And I have an exercise in category "shoulders"
+    And I have a workout with a set of 30 kg for 12 reps
+    When I click clone on my set
+    Then the Add Set form is pre-filled with weight 30 and reps 12

--- a/tests/e2e/features/workouts/visibility.feature
+++ b/tests/e2e/features/workouts/visibility.feature
@@ -1,0 +1,25 @@
+Feature: Workout visibility and not-found behaviour
+
+  Locks the data-isolation contract: a workout belongs to the user
+  who logged it; other users should neither see it on their list nor
+  be able to navigate to it.
+
+  Scenario: Another user cannot see my workout in their list
+    Given I am logged in as "lifter"
+    And I have a workout
+    When I switch to a fresh non-admin user
+    Then I do not see the workout I created on the workouts page
+
+  Scenario: Another user gets a 404 when visiting my workout
+    Given I am logged in as "lifter"
+    And I have a workout
+    When I switch to a fresh non-admin user
+    Then visiting the workout I created returns a 404
+
+  Scenario: A fresh user sees the empty state on /workouts
+    Given I am logged in as a fresh non-admin user
+    Then I see the workouts empty state
+
+  Scenario: Visiting a nonexistent workout returns 404
+    Given I am logged in as "lifter"
+    Then visiting "/workouts/00000000-0000-0000-0000-000000000000" returns a 404

--- a/tests/e2e/steps/auth.steps.js
+++ b/tests/e2e/steps/auth.steps.js
@@ -107,3 +107,17 @@ Given(
     ).toBeVisible();
   },
 );
+
+When(
+  'I switch to a fresh non-admin user',
+  async ({ context, page, request, baseURL, scenarioState }) => {
+    await context.clearCookies();
+    const username = scenarioState.unique('other');
+    scenarioState.currentUser = username;
+    await ensureUser(request, baseURL, username, ADMIN.password);
+    await loginViaUi(page, username, ADMIN.password);
+    await expect(
+      page.getByRole('heading', { name: 'Dashboard', level: 1 }),
+    ).toBeVisible();
+  },
+);

--- a/tests/e2e/steps/dashboard.steps.js
+++ b/tests/e2e/steps/dashboard.steps.js
@@ -1,0 +1,27 @@
+import { expect } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+import { test } from './fixtures.js';
+
+const { Then } = createBdd(test);
+
+Then(
+  'the dashboard lists the workout I created in Recent Workouts',
+  async ({ page, scenarioState }) => {
+    await page.goto('/');
+    await expect(
+      page.getByRole('heading', { name: 'Recent Workouts', level: 2 }),
+    ).toBeVisible();
+    await expect(
+      page.locator(`.workout-list a[href="/workouts/${scenarioState.workoutId}"]`),
+    ).toBeVisible();
+  },
+);
+
+Then(
+  'the dashboard {string} count is {int}',
+  async ({ page }, label, count) => {
+    await page.goto('/');
+    const card = page.locator('.stat-card').filter({ hasText: label });
+    await expect(card.locator('.stat-value')).toHaveText(String(count));
+  },
+);

--- a/tests/e2e/steps/exercises.steps.js
+++ b/tests/e2e/steps/exercises.steps.js
@@ -4,29 +4,33 @@ import { test } from './fixtures.js';
 
 const { Given, When, Then } = createBdd(test);
 
-async function createExercise(page, name, category) {
+async function createExercise(page, scenarioState, name, category) {
   await page.goto('/exercises/new');
   await page.getByLabel('Name').fill(name);
   await page.getByLabel('Category').selectOption(category);
   await page.getByRole('button', { name: 'Add Exercise' }).click();
   await expect(page).toHaveURL('/exercises');
+  scenarioState.exerciseName = name;
+  // /exercises lists each exercise as <a href="/stats/exercise/{id}">{name}</a>.
+  const href = await page
+    .getByRole('link', { name })
+    .first()
+    .getAttribute('href');
+  scenarioState.exerciseId =
+    href?.match(/\/stats\/exercise\/([^/]+)/)?.[1] ?? null;
 }
 
 When(
   'I create a new exercise in category {string}',
   async ({ page, scenarioState }, category) => {
-    const name = scenarioState.unique('Squat');
-    await createExercise(page, name, category);
-    scenarioState.exerciseName = name;
+    await createExercise(page, scenarioState, scenarioState.unique('Squat'), category);
   },
 );
 
 Given(
   'I have an exercise in category {string}',
   async ({ page, scenarioState }, category) => {
-    const name = scenarioState.unique('Exercise');
-    await createExercise(page, name, category);
-    scenarioState.exerciseName = name;
+    await createExercise(page, scenarioState, scenarioState.unique('Exercise'), category);
   },
 );
 

--- a/tests/e2e/steps/settings.steps.js
+++ b/tests/e2e/steps/settings.steps.js
@@ -1,6 +1,7 @@
 import { expect } from '@playwright/test';
 import { createBdd } from 'playwright-bdd';
 import { test } from './fixtures.js';
+import { ADMIN } from '../support/seeding.js';
 
 const { When, Then } = createBdd(test);
 
@@ -34,4 +35,53 @@ Then('I see a password-change success message', async ({ page }) => {
 
 Then('I see a settings error {string}', async ({ page }, message) => {
   await expect(page.locator('.error')).toContainText(message);
+});
+
+function sessionsTable(page) {
+  return page
+    .locator('table.data-table')
+    .filter({
+      has: page.getByRole('columnheader', { name: 'Device' }),
+    });
+}
+
+When(
+  'I have a second session as {string}',
+  async ({ playwright, baseURL }, username) => {
+    const ctx = await playwright.request.newContext({ baseURL });
+    try {
+      const res = await ctx.post('/auth/login', {
+        form: { username, password: ADMIN.password },
+        maxRedirects: 0,
+        failOnStatusCode: false,
+      });
+      expect(
+        [302, 303],
+        `second-session login expected redirect, got ${res.status()}`,
+      ).toContain(res.status());
+    } finally {
+      await ctx.dispose();
+    }
+  },
+);
+
+When('I log out all other devices', async ({ page }) => {
+  await page.goto('/settings');
+  page.once('dialog', (d) => d.accept());
+  await page
+    .getByRole('button', { name: 'Log out all other devices' })
+    .click();
+});
+
+Then(
+  'the active sessions table has {int} row(s)',
+  async ({ page }, count) => {
+    await page.goto('/settings');
+    await expect(sessionsTable(page).locator('tbody tr')).toHaveCount(count);
+  },
+);
+
+Then('the active sessions table marks my current device', async ({ page }) => {
+  await page.goto('/settings');
+  await expect(sessionsTable(page).getByText('This device')).toBeVisible();
 });

--- a/tests/e2e/steps/stats.steps.js
+++ b/tests/e2e/steps/stats.steps.js
@@ -1,0 +1,36 @@
+import { expect } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+import { test } from './fixtures.js';
+
+const { Then } = createBdd(test);
+
+Then('I see the stats overview', async ({ page }) => {
+  await page.goto('/stats');
+  await expect(
+    page.getByRole('heading', { name: 'Statistics', level: 1 }),
+  ).toBeVisible();
+  await expect(page.locator('.stats-grid')).toBeVisible();
+});
+
+Then(
+  'I see exercise-specific stats for the exercise I created',
+  async ({ page, scenarioState }) => {
+    await page.goto(`/stats/exercise/${scenarioState.exerciseId}`);
+    await expect(
+      page.getByRole('heading', {
+        name: scenarioState.exerciseName,
+        level: 1,
+      }),
+    ).toBeVisible();
+    // Once any set has been logged, the chart SVG renders; the "No
+    // progress data yet" fallback only appears for empty exercises.
+    await expect(page.locator('#exercise-chart')).toBeVisible();
+  },
+);
+
+Then('the PR list shows my exercise', async ({ page, scenarioState }) => {
+  await page.goto('/stats/prs');
+  await expect(
+    page.getByRole('link', { name: scenarioState.exerciseName }),
+  ).toBeVisible();
+});

--- a/tests/e2e/steps/users.steps.js
+++ b/tests/e2e/steps/users.steps.js
@@ -86,3 +86,13 @@ Then('visiting {string} returns a 403', async ({ page }, path) => {
   const response = await page.goto(path);
   expect(response?.status()).toBe(403);
 });
+
+Then(
+  'the users page does not let me delete my own account',
+  async ({ page }) => {
+    await page.goto('/users');
+    const myRow = page.locator('tr').filter({ hasText: 'lifter' }).first();
+    await expect(myRow.getByText('(you)')).toBeVisible();
+    await expect(myRow.getByRole('button', { name: 'Delete' })).toHaveCount(0);
+  },
+);

--- a/tests/e2e/steps/workouts.steps.js
+++ b/tests/e2e/steps/workouts.steps.js
@@ -175,3 +175,105 @@ Then('my set is flagged as a PR', async ({ page, scenarioState }) => {
     .first();
   await expect(row.locator('.pr-badge')).toBeVisible();
 });
+
+When(
+  'I log a set of {int} kg for {int} reps with RPE {int} using the exercise I created',
+  async ({ page, scenarioState }, weight, reps, rpe) => {
+    await page.goto(`/workouts/${scenarioState.workoutId}`);
+    await page
+      .locator('select#exercise_id')
+      .selectOption({ label: scenarioState.exerciseName });
+    await page.getByLabel('Weight').fill(String(weight));
+    await page.getByLabel('Reps').fill(String(reps));
+    await page.getByLabel('RPE (1-10, optional)').fill(String(rpe));
+    await page.getByRole('button', { name: 'Add Set' }).click();
+    await expect(
+      page.locator('.set-row').filter({ hasText: scenarioState.exerciseName }).first(),
+    ).toBeVisible();
+  },
+);
+
+Then(
+  'I see my set logged with RPE {int}',
+  async ({ page, scenarioState }, rpe) => {
+    await page.goto(`/workouts/${scenarioState.workoutId}`);
+    const row = page
+      .locator('.set-row')
+      .filter({ hasText: scenarioState.exerciseName })
+      .first();
+    await expect(row.locator('.set-cell-rpe')).toHaveText(String(rpe));
+  },
+);
+
+When(
+  'I log another set of {int} kg for {int} reps using the same exercise',
+  async ({ page, scenarioState }, weight, reps) => {
+    await page.goto(`/workouts/${scenarioState.workoutId}`);
+    await page
+      .locator('select#exercise_id')
+      .selectOption({ label: scenarioState.exerciseName });
+    await page.getByLabel('Weight').fill(String(weight));
+    await page.getByLabel('Reps').fill(String(reps));
+    await page.getByRole('button', { name: 'Add Set' }).click();
+  },
+);
+
+Then('I see two sets numbered 1 and 2', async ({ page, scenarioState }) => {
+  await page.goto(`/workouts/${scenarioState.workoutId}`);
+  const rows = page
+    .locator('.set-row')
+    .filter({ hasText: scenarioState.exerciseName });
+  await expect(rows).toHaveCount(2);
+  const numbers = (
+    await rows.locator('.set-cell-set').allTextContents()
+  ).sort();
+  expect(numbers).toEqual(['1', '2']);
+});
+
+When('I click clone on my set', async ({ page, scenarioState }) => {
+  await page.goto(`/workouts/${scenarioState.workoutId}`);
+  const row = page
+    .locator('.set-row')
+    .filter({ hasText: scenarioState.exerciseName })
+    .first();
+  await row.getByRole('button', { name: 'Clone' }).click();
+});
+
+Then(
+  'the Add Set form is pre-filled with weight {int} and reps {int}',
+  async ({ page, scenarioState }, weight, reps) => {
+    expect(await page.locator('select#exercise_id').inputValue()).toBe(
+      scenarioState.exerciseId,
+    );
+    await expect(page.getByLabel('Weight')).toHaveValue(String(weight));
+    await expect(page.getByLabel('Reps')).toHaveValue(String(reps));
+  },
+);
+
+Then(
+  'visiting the workout I created returns a 404',
+  async ({ page, scenarioState }) => {
+    const response = await page.goto(`/workouts/${scenarioState.workoutId}`);
+    expect(response?.status()).toBe(404);
+  },
+);
+
+Then(
+  'I do not see the workout I created on the workouts page',
+  async ({ page, scenarioState }) => {
+    await page.goto('/workouts');
+    await expect(
+      page.locator(`a[href="/workouts/${scenarioState.workoutId}"]`),
+    ).toHaveCount(0);
+  },
+);
+
+Then('I see the workouts empty state', async ({ page }) => {
+  await page.goto('/workouts');
+  await expect(page.locator('.empty-state')).toContainText('No workouts yet');
+});
+
+Then('visiting {string} returns a 404', async ({ page }, path) => {
+  const response = await page.goto(path);
+  expect(response?.status()).toBe(404);
+});


### PR DESCRIPTION
## Summary

Takes the BDD suite from 29 to 44 scenarios. Fills the remaining big gaps in user-visible behaviour and a few small but breakage-prone interactions.

| Area | Scenarios |
|---|---|
| stats | ``/stats`` overview; ``/stats/exercise/{id}`` chart for an exercise with logs; ``/stats/prs`` lists a fresh PR |
| dashboard | newly created workout appears in Recent Workouts; "This Week" count goes 0 → 1 |
| sessions | log-out-other-devices drops the table from 2 rows to 1; current device is marked |
| workouts | RPE round-trips; sets auto-number 1/2 within a workout; Clone-set button pre-fills the form; cross-user list isolation; cross-user 404; fresh-user empty state; nonexistent id 404 |
| users | admin cannot delete their own account (UI shows ``(you)`` and hides the Delete button) |

## Notable mechanics

- **``exerciseId`` capture.** Stats steps need the exercise id, so the existing ``createExercise`` helper now reads the ``/stats/exercise/{id}`` href off the freshly added row in the exercises list and stashes it on ``scenarioState``.
- **User switching.** ``When I switch to a fresh non-admin user`` clears cookies, seeds a unique member through the admin's HTTP context, then UI-logs-in. ``scenarioState.workoutId`` is preserved, which is what lets the cross-user assertions test "another user can't see / open *that* workout".
- **Second session.** ``I have a second session as <user>`` uses ``playwright.request.newContext({ baseURL })`` to log in over an isolated APIRequestContext — the cookie there doesn't leak into the page, but the session row it creates is what makes the active-sessions table show 2 rows.
- **Auto-numbering assertion is order-agnostic.** Set rows are returned newest-first, so the test sorts the ``set-cell-set`` values and compares against ``[1, 2]`` rather than asserting display order.

## Test plan

- [ ] ``cd tests/e2e && npm test`` — expect 44 scenarios passing
- [ ] CI e2e job stays green
- [ ] Spot-check the HTML report

🤖 Generated with [Claude Code](https://claude.com/claude-code)