### PR TITLE
feat(shutdown): checkpoint WAL and stop sweep cleanly on shutdown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 axum = { version = "0.8", features = ["macros"] }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal", "sync"] }
 askama = "0.16"
 time = "0.3"
 rusqlite = { version = "0.32", features = ["bundled", "chrono"] }

--- a/src/db.rs
+++ b/src/db.rs
@@ -29,6 +29,17 @@ pub fn create_pool(database_url: &str) -> Result<DbPool, r2d2::Error> {
     Pool::builder().max_size(10).build(manager)
 }
 
+/// Flush the WAL back into the main database and truncate the `-wal` file.
+///
+/// Run on graceful shutdown so the on-disk DB is self-contained; the `-wal`
+/// and `-shm` siblings are then removed by SQLite when the pool's last
+/// connection closes.
+pub fn checkpoint(pool: &DbPool) -> anyhow::Result<()> {
+    let conn = pool.get()?;
+    conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")?;
+    Ok(())
+}
+
 #[allow(dead_code)]
 pub fn create_memory_pool() -> Result<DbPool, r2d2::Error> {
     let manager = SqliteConnectionManager::memory();
@@ -88,6 +99,31 @@ mod tests {
             .expect("synchronous");
         // NORMAL == 1 (FULL == 2, OFF == 0).
         assert_eq!(sync, 1);
+    }
+
+    #[test]
+    fn checkpoint_truncates_wal_file() {
+        let tmp = TempDbPath::new();
+        let pool = create_pool(&tmp.url()).expect("file pool");
+        {
+            let conn = pool.get().expect("get conn");
+            conn.execute_batch(
+                "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT);\
+                 INSERT INTO t (v) VALUES ('a'), ('b'), ('c');",
+            )
+            .expect("write");
+        }
+
+        let wal_path = format!("{}-wal", tmp.0.display());
+        let before = std::fs::metadata(&wal_path).expect("wal exists").len();
+        assert!(before > 0, "WAL should have frames before checkpoint");
+
+        checkpoint(&pool).expect("checkpoint");
+
+        let after = std::fs::metadata(&wal_path)
+            .expect("wal still exists")
+            .len();
+        assert_eq!(after, 0, "TRUNCATE checkpoint should zero the WAL file");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,22 +50,30 @@ async fn main() -> anyhow::Result<()> {
     let workout_repo = WorkoutRepository::new(pool.clone());
     let session_repo = SessionRepository::new(pool.clone());
 
+    // Broadcasts the shutdown request to the background sweep so it can stop
+    // cleanly before we checkpoint the WAL.
+    let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
+
     // Periodic background sweep of expired session rows. validate_and_touch
     // already lazily deletes stale rows it sees, but orphans (sessions never
     // revisited) need this sweep to avoid unbounded table growth.
-    {
+    let sweep_handle = {
         let session_repo = session_repo.clone();
         tokio::spawn(async move {
             let mut ticker = tokio::time::interval(std::time::Duration::from_secs(60 * 60));
             ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
             loop {
-                ticker.tick().await;
-                if let Err(e) = session_repo.cleanup_expired().await {
-                    tracing::warn!(error = ?e, "session cleanup_expired failed");
+                tokio::select! {
+                    _ = ticker.tick() => {
+                        if let Err(e) = session_repo.cleanup_expired().await {
+                            tracing::warn!(error = ?e, "session cleanup_expired failed");
+                        }
+                    }
+                    _ = shutdown_rx.changed() => break,
                 }
             }
-        });
-    }
+        })
+    };
 
     let app_state = AppState {
         user_repo,
@@ -85,6 +93,21 @@ async fn main() -> anyhow::Result<()> {
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal())
         .await?;
+
+    // Server has stopped accepting connections and drained in-flight requests.
+    // Stop the background sweep and wait for any current pass to finish before
+    // we touch the DB.
+    let _ = shutdown_tx.send(true);
+    if let Err(e) = sweep_handle.await {
+        tracing::warn!(error = ?e, "session sweep task did not stop cleanly");
+    }
+
+    // Checkpoint the WAL so the main DB file is self-contained. The pool (and
+    // its connections) drops at the end of main, after which SQLite removes
+    // the now-empty -wal/-shm siblings.
+    if let Err(e) = db::checkpoint(&pool) {
+        tracing::warn!(error = ?e, "WAL checkpoint on shutdown failed");
+    }
 
     tracing::info!("Server shut down gracefully");
     Ok(())


### PR DESCRIPTION
## Summary

On graceful shutdown the app left the SQLite `-wal`/`-shm` siblings on disk, and the periodic session-expiry sweep ran an unbounded loop with no shutdown awareness (it was simply dropped when the runtime tore down).

This wires a clean shutdown sequence so the on-disk DB is self-contained after exit:

1. Server stops accepting connections and drains in-flight requests (existing `with_graceful_shutdown`).
2. A `tokio::sync::watch` channel signals the background sweep to stop; the sweep loop now `select!`s on it and breaks, and `main` joins the task so any in-flight `cleanup_expired` pass completes.
3. `db::checkpoint` runs `PRAGMA wal_checkpoint(TRUNCATE)` to fold the WAL back into the main DB. When the pool's last connection closes (at the end of `main`), SQLite removes the now-empty `-wal`/`-shm` files.

This holds on a clean shutdown (Ctrl+C / SIGTERM within the graceful timeout). A hard `SIGKILL` can still leave the siblings behind, but that is harmless — `synchronous=NORMAL` + WAL recovers on next open.

## Changes

- `src/db.rs`: add `checkpoint(&DbPool)` + a TDD unit test asserting the WAL is truncated to zero bytes.
- `src/main.rs`: shutdown-aware background sweep via `watch` channel, join-then-checkpoint sequence after the server stops.
- `Cargo.toml`: enable tokio `sync` feature for the watch channel.

## Verification

- `cargo fmt --all -- --check` and `cargo clippy -- -D warnings`: clean
- `cargo nextest run`: 284 passed
- Manual: ran the binary against a temp DB; while running both `-wal` and `-shm` were present; after `SIGTERM` only the main `.sqlite3` remained (exit 0, "Server shut down gracefully" logged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)