### PR TITLE
feat(workouts): show last RPE in the exercise Last info

### DIFF
--- a/docs/superpowers/specs/2026-06-25-last-show-rpe-design.md
+++ b/docs/superpowers/specs/2026-06-25-last-show-rpe-design.md
@@ -1,0 +1,65 @@
+# Last 顯示加入 RPE — Design
+
+Date: 2026-06-25
+Branch: `feat/last-show-rpe`
+
+## Problem
+
+在 workout 頁面選擇某個 exercise 時，`.pr-info` 的「Last」資訊條目前只顯示上次的 weight 與日期
+（`Last: 100 kg @ 2026-06-20`）。使用者要靠上次的 RPE（自覺強度）來判斷這次要不要加重，但 RPE 沒有顯示出來。
+
+## Goal
+
+讓「Last」資訊條在 weight 與日期之外，也顯示上次該 exercise 最近一筆紀錄的 RPE，以 chip 形式呈現。
+若上次沒填 RPE，顯示「RPE —」佔位，讓使用者明確知道「沒紀錄」而非「漏看」。
+
+最終樣式（方案 B + 佔位）：
+
+```
+有 RPE：  Last: 100 kg  [RPE 8]  2026-06-20   [Fill]
+無 RPE：  Last: 100 kg  [RPE —]  2026-06-20   [Fill]
+```
+
+`[RPE 8]` 為金色外框 chip（沿用 `.rpe-chip`），佔位版為虛線、淡化。
+
+## Scope
+
+最小改動，4 個檔案：
+
+1. **SQL** — `src/repositories/workout_repo.rs::get_last_weight_per_exercise_by_user`
+   - SELECT 多帶 `wl.rpe`。
+   - 現有查詢以 `GROUP BY wl.exercise_id` + `MAX(wl.created_at)` 取每個 exercise 最近一筆。
+     依 SQLite 的 bare-column 規則，當 SELECT 含 `MAX()` 聚合時，其他裸欄位（`weight`、`rpe`）取自
+     該 `MAX` 所在的同一列，因此 `rpe` 與既有的 `weight` 來自同一筆「最新」紀錄，語意一致。
+
+2. **Model** — `src/models/personal_record.rs::LastExerciseWeight`
+   - 新增欄位 `rpe: Option<i32>`。
+   - 更新 `from_row` 對應新的 SELECT 欄位順序。
+
+3. **Template + JS** — `templates/workouts/show.html`
+   - server-side 產生的 `exerciseLastWeights[exerciseId]` 物件多塞 `rpe`（值或 `null`）。
+   - `showLastWeightInfo()` 在 weight 與日期之間插入 RPE chip：
+     - `rpe` 有值 → `<span class="rpe-chip">RPE {n}</span>`
+     - `rpe` 為 `null` → `<span class="rpe-chip rpe-chip-empty">RPE —</span>`
+   - `fillLastWeight()` 行為不變：只填 weight，不動 RPE 欄位。
+
+4. **CSS** — `templates/base.html`
+   - 新增 `.rpe-chip`：金色外框（`border: 1px solid var(--gold)`、`color: var(--gold)`、
+     `font-family: var(--font-display)`、`font-size: var(--font-xs)`、`padding: 1px var(--sp-2)`、
+     `border-radius: var(--radius)`）。
+   - 新增 `.rpe-chip-empty`：`border-style: dashed`、降低不透明度，表示「無紀錄」。
+
+## Tests
+
+- **整合測試**（`tests/` 對應 workout repo）：`get_last_weight_per_exercise_by_user` 回傳的
+  `LastExerciseWeight` 含正確 `rpe`，涵蓋兩種情況：
+  - 最近一筆有填 RPE → `Some(n)`。
+  - 最近一筆沒填 RPE → `None`。
+- **E2E**（`tests/e2e/`）：若既有 last-weight 場景存在，擴充斷言 `.pr-info` 內出現 RPE chip；
+  否則新增一個場景：建立一筆有 RPE 的 set，重新選同一 exercise，驗證 chip 文字為 `RPE 8`。
+
+## Out of Scope
+
+- Fill 不會自動填入 RPE（維持最小改動）。
+- 不顯示上次的 reps（使用者選 B 而非 C）。
+- 不改動既有 RPE 的輸入 / 編輯 / stats 顯示。

--- a/src/models/personal_record.rs
+++ b/src/models/personal_record.rs
@@ -30,6 +30,7 @@ pub struct LastExerciseWeight {
     pub exercise_id: String,
     pub exercise_name: String,
     pub weight: f64,
+    pub rpe: Option<i32>,
     pub logged_at: DateTime<Utc>,
 }
 
@@ -39,6 +40,7 @@ impl FromSqliteRow for LastExerciseWeight {
             exercise_id: row.get("exercise_id")?,
             exercise_name: row.get("exercise_name")?,
             weight: row.get("weight")?,
+            rpe: row.get("rpe")?,
             logged_at: row.get("logged_at")?,
         })
     }

--- a/src/repositories/workout_repo.rs
+++ b/src/repositories/workout_repo.rs
@@ -374,6 +374,7 @@ impl WorkoutRepository {
             let mut stmt = conn.prepare(
                 "SELECT wl.exercise_id, e.name as exercise_name,
                         wl.weight as weight,
+                        wl.rpe as rpe,
                         MAX(wl.created_at) as logged_at
                  FROM workout_logs wl
                  JOIN workout_sessions ws ON wl.session_id = ws.id
@@ -1186,10 +1187,10 @@ mod tests {
         repo.create_log(&session.id, "ex-bench-press", 2, 8, 110.0, None)
             .await
             .unwrap();
-        repo.create_log(&session.id, "ex-bench-press", 3, 5, 105.0, None)
+        repo.create_log(&session.id, "ex-bench-press", 3, 5, 105.0, Some(8))
             .await
             .unwrap();
-        // Squat: single set
+        // Squat: single set, no RPE recorded
         repo.create_log(&session.id, "ex-squat", 1, 5, 150.0, None)
             .await
             .unwrap();
@@ -1211,6 +1212,9 @@ mod tests {
         // Last logged weight, NOT the max
         assert_eq!(bench.weight, 105.0);
         assert_eq!(squat.weight, 150.0);
+        // RPE comes from the same latest row as the weight
+        assert_eq!(bench.rpe, Some(8));
+        assert_eq!(squat.rpe, None);
     }
 
     #[tokio::test]

--- a/templates/base.html
+++ b/templates/base.html
@@ -731,6 +731,23 @@
             50% { box-shadow: 0 0 12px var(--gold-muted), 0 0 24px rgba(255, 184, 0, 0.08); }
         }
 
+        .rpe-chip {
+            display: inline-block;
+            font-family: var(--font-display);
+            font-size: var(--font-xs);
+            font-weight: 700;
+            letter-spacing: 0.06em;
+            padding: 1px var(--sp-2);
+            border: 1px solid var(--gold);
+            color: var(--gold);
+            border-radius: var(--radius);
+        }
+
+        .rpe-chip-empty {
+            border-style: dashed;
+            opacity: 0.6;
+        }
+
         /* ============================================
            PR INFO BAR
            ============================================ */

--- a/templates/workouts/show.html
+++ b/templates/workouts/show.html
@@ -125,6 +125,7 @@ var exerciseLastWeights = {};
 {% for entry in exercise_last_weights %}
 exerciseLastWeights["{{ entry.exercise_id }}"] = {
     weight: {{ entry.weight }},
+    rpe: {% match entry.rpe %}{% when Some with (r) %}{{ r }}{% when None %}null{% endmatch %},
     date: "{{ entry.logged_at.format("%Y-%m-%d") }}"
 };
 {% endfor %}
@@ -135,7 +136,11 @@ var exerciseSelect = document.getElementById('exercise_id');
 function showLastWeightInfo(exerciseId) {
     if (exerciseId && exerciseLastWeights[exerciseId]) {
         var entry = exerciseLastWeights[exerciseId];
-        lastWeightInfoEl.innerHTML = "Last: " + entry.weight + " kg @ " + entry.date +
+        var rpeHtml = (entry.rpe !== null)
+            ? '<span class="rpe-chip">RPE ' + entry.rpe + '</span>'
+            : '<span class="rpe-chip rpe-chip-empty">RPE —</span>';
+        lastWeightInfoEl.innerHTML = "Last: " + entry.weight + " kg " + rpeHtml +
+            ' <span class="muted">' + entry.date + '</span>' +
             ' <button type="button" class="btn btn-sm btn-inline" style="background:var(--gold);color:var(--text-inverse);border-color:var(--gold);" onclick="fillLastWeight()">Fill</button>';
         lastWeightInfoEl.classList.add('visible');
     } else {

--- a/tests/e2e/features/workouts/lifecycle.feature
+++ b/tests/e2e/features/workouts/lifecycle.feature
@@ -57,6 +57,21 @@ Feature: Workout lifecycle
     When I log another set of 50 kg for 8 reps using the same exercise
     Then I see two sets numbered 1 and 2
 
+  Scenario: Last info shows the previous RPE when selecting an exercise
+    Given I am logged in as "lifter"
+    And I have an exercise in category "chest"
+    And I have a workout
+    When I log a set of 100 kg for 5 reps with RPE 8 using the exercise I created
+    And I select the exercise I created on the workout page
+    Then the Last info shows "RPE 8"
+
+  Scenario: Last info shows an RPE placeholder when the last set had no RPE
+    Given I am logged in as "lifter"
+    And I have an exercise in category "chest"
+    And I have a workout with a set of 60 kg for 8 reps
+    When I select the exercise I created on the workout page
+    Then the Last info shows "RPE —"
+
   Scenario: Clone-set button pre-fills the Add Set form
     Given I am logged in as "lifter"
     And I have an exercise in category "shoulders"

--- a/tests/e2e/steps/workouts.steps.js
+++ b/tests/e2e/steps/workouts.steps.js
@@ -206,6 +206,25 @@ Then(
 );
 
 When(
+  'I select the exercise I created on the workout page',
+  async ({ page, scenarioState }) => {
+    await page.goto(`/workouts/${scenarioState.workoutId}`);
+    await page
+      .locator('select#exercise_id')
+      .selectOption({ label: scenarioState.exerciseName });
+  },
+);
+
+Then(
+  'the Last info shows {string}',
+  async ({ page }, text) => {
+    const info = page.locator('#exercise-last-weight-info');
+    await expect(info).toBeVisible();
+    await expect(info.locator('.rpe-chip')).toHaveText(text);
+  },
+);
+
+When(
   'I log another set of {int} kg for {int} reps using the same exercise',
   async ({ page, scenarioState }, weight, reps) => {
     await page.goto(`/workouts/${scenarioState.workoutId}`);


### PR DESCRIPTION
## Summary

When selecting an exercise during a workout, the **Last** info bar now shows the RPE of the most recent set alongside weight and date, so you can decide whether to add weight this session.

- `Last: 100 kg [RPE 8] 2026-06-20 [Fill]` — RPE rendered as a gold-outline chip
- `Last: 100 kg [RPE —] 2026-06-20 [Fill]` — dashed placeholder when the last set had no RPE

`Fill` behaviour is unchanged (weight only). Reps are intentionally not shown.

## Changes

- `LastExerciseWeight`: add `rpe: Option<i32>` field + `from_row`
- `get_last_weight_per_exercise_by_user`: select `wl.rpe` (same latest row as `weight` via SQLite bare-column rule)
- `templates/workouts/show.html`: render the RPE chip in `showLastWeightInfo()`
- `templates/base.html`: new `.rpe-chip` / `.rpe-chip-empty` styles
- Design spec under `docs/superpowers/specs/`

## Tests

- Repo unit test extended to assert RPE for both `Some(8)` and `None` cases — full Rust suite (284) passes locally
- Two E2E scenarios added (RPE chip + placeholder); `bddgen` discovers them. E2E browser could not be installed locally due to a Playwright CDN download stall, so these run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)