### PR TITLE
chore(infra): toolchain 1.96.0, Rust 2024 edition, cargo-deny, Swatinem cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,15 +25,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -51,6 +43,17 @@ jobs:
         if: runner.os != 'Linux'
         run: cargo nextest run
 
+  deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@10c3493d811a9096cee4fdf287e41e852f6a51ba # 1.94.0
+      - uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2
+        with:
+          tool: cargo-deny@0.18.9
+      - name: cargo deny check
+        run: cargo deny check
+
   e2e:
     runs-on: ubuntu-latest
     steps:
@@ -63,16 +66,7 @@ jobs:
         uses: dtolnay/rust-toolchain@10c3493d811a9096cee4fdf287e41e852f6a51ba # 1.94.0
 
       - name: Cache cargo
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-e2e-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-e2e-
-            ${{ runner.os }}-cargo-
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -131,16 +125,7 @@ jobs:
           components: llvm-tools-preview
 
       - name: Cache dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-coverage-
-            ${{ runner.os }}-cargo-
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - uses: taiki-e/install-action@ad25acb6b9413207b3174a4202c12aa9133691c6 # cargo-llvm-cov
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ LiftLog is a self-hosted workout journal: an Axum + Askama server-rendered app b
 cargo run                                 # dev server on $PORT (default 3000)
 cargo fmt --all -- --check                # formatting gate
 cargo clippy -- -D warnings               # lint gate
+cargo deny check                          # supply-chain gate (advisories/licenses/bans/sources)
 cargo nextest run                         # Rust integration + unit tests
 cargo nextest run --test workout_test     # single integration file
 cargo nextest run -p liftlog session_repo # filter by name

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "liftlog"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 axum = { version = "0.8", features = ["macros"] }

--- a/build.rs
+++ b/build.rs
@@ -19,10 +19,11 @@ fn main() {
 
 fn get_git_version() -> String {
     // Tier 1: Use environment variable (for Docker/CI builds)
-    if let Ok(version) = std::env::var("GIT_VERSION") {
-        if !version.is_empty() && version != "dev" {
-            return version;
-        }
+    if let Ok(version) = std::env::var("GIT_VERSION")
+        && !version.is_empty()
+        && version != "dev"
+    {
+        return version;
     }
 
     // Tier 2: Use git describe

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,52 @@
+# cargo-deny configuration — supply-chain checks for the dependency graph.
+# Run locally with `cargo deny check`; CI runs the same on every push and PR.
+
+[graph]
+# Check the dependency graph for all targets, not just the host's, so a
+# platform-specific dependency can't smuggle in a bad license or advisory.
+all-features = true
+
+[advisories]
+version = 2
+# Deny crates with a known security advisory (RUSTSEC) or that have been yanked.
+# `ignore` holds advisory IDs we've reviewed and consciously accept (none yet).
+yanked = "deny"
+ignore = [
+    # memmap2 unchecked pointer offset (unsound). Fixed in 0.9.11, but that
+    # release is younger than our 7-day dependency cooldown — re-bump and drop
+    # this entry once it has aged out.
+    "RUSTSEC-2026-0186",
+]
+
+[licenses]
+version = 2
+# Permissive / public-domain-equivalent licenses only. Verify the active set
+# with `cargo deny list`; add a license here only after reviewing the crate.
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MIT",
+    "MIT-0",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+confidence-threshold = 0.8
+
+[bans]
+# Duplicate transitive versions are common; surface them as a warning, not a
+# hard failure.
+multiple-versions = "warn"
+wildcards = "deny"
+
+[sources]
+# Only crates.io is trusted; an unknown registry or any git source is rejected.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.94.0"
+channel = "1.96.0"
 components = ["clippy", "rustfmt"]

--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -1,8 +1,8 @@
 use askama::Template;
 use axum::{
+    Form,
     extract::{Path, Request, State},
     response::{Html, IntoResponse, Redirect, Response},
-    Form,
 };
 use axum_extra::extract::CookieJar;
 

--- a/src/handlers/exercises.rs
+++ b/src/handlers/exercises.rs
@@ -1,13 +1,13 @@
 use askama::Template;
 use axum::{
+    Form,
     extract::{Path, State},
     response::{Html, IntoResponse, Redirect, Response},
-    Form,
 };
 
 use crate::error::Result;
 use crate::middleware::AuthUser;
-use crate::models::exercise::{ExerciseCategory, CATEGORIES};
+use crate::models::exercise::{CATEGORIES, ExerciseCategory};
 use crate::models::{CreateExercise, Exercise, UpdateExercise};
 use crate::state::AppState;
 

--- a/src/handlers/favicon.rs
+++ b/src/handlers/favicon.rs
@@ -1,5 +1,5 @@
 use axum::{
-    http::{header, HeaderValue, StatusCode},
+    http::{HeaderValue, StatusCode, header},
     response::IntoResponse,
 };
 

--- a/src/handlers/settings.rs
+++ b/src/handlers/settings.rs
@@ -1,8 +1,8 @@
 use askama::Template;
 use axum::{
+    Form,
     extract::State,
     response::{Html, IntoResponse, Response},
-    Form,
 };
 use serde::Deserialize;
 

--- a/src/handlers/workouts.rs
+++ b/src/handlers/workouts.rs
@@ -1,15 +1,15 @@
 use askama::Template;
 use axum::{
+    Form,
     extract::{Path, Query, State},
     response::{Html, IntoResponse, Redirect, Response},
-    Form,
 };
 use chrono::NaiveDate;
 use serde::Deserialize;
 
 use crate::error::{AppError, Result};
 use crate::middleware::AuthUser;
-use crate::models::exercise::{ExerciseCategory, CATEGORIES};
+use crate::models::exercise::{CATEGORIES, ExerciseCategory};
 use crate::models::{
     CreateWorkoutLog, CreateWorkoutSession, Exercise, LastExerciseWeight, UpdateWorkoutLog,
     WorkoutLog, WorkoutLogWithExercise, WorkoutSession,

--- a/src/middleware/auth.rs
+++ b/src/middleware/auth.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::{FromRequestParts, Request, State},
-    http::{request::Parts, StatusCode},
+    http::{StatusCode, request::Parts},
     middleware::Next,
     response::{IntoResponse, Redirect, Response},
 };

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1,3 +1,3 @@
 pub mod auth;
 
-pub use auth::{sliding_session_middleware, AdminUser, AuthUser, SuppressSessionRefresh};
+pub use auth::{AdminUser, AuthUser, SuppressSessionRefresh, sliding_session_middleware};

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -62,10 +62,9 @@ pub fn run_migrations(pool: &DbPool) -> anyhow::Result<()> {
 
     let applied: HashSet<String> = {
         let mut stmt = conn.prepare("SELECT name FROM _migrations")?;
-        let rows = stmt
-            .query_map([], |row| row.get::<_, String>(0))?
-            .collect::<rusqlite::Result<HashSet<String>>>()?;
-        rows
+
+        stmt.query_map([], |row| row.get::<_, String>(0))?
+            .collect::<rusqlite::Result<HashSet<String>>>()?
     };
 
     for (filename, sql) in MIGRATIONS {

--- a/src/repositories/session_repo.rs
+++ b/src/repositories/session_repo.rs
@@ -444,11 +444,12 @@ mod tests {
 
         repo.cleanup_expired().await.unwrap();
 
-        assert!(repo
-            .validate_and_touch(&token_valid)
-            .await
-            .unwrap()
-            .is_some());
+        assert!(
+            repo.validate_and_touch(&token_valid)
+                .await
+                .unwrap()
+                .is_some()
+        );
 
         let conn = pool.get().unwrap();
         let count: i64 = conn

--- a/src/repositories/user_repo.rs
+++ b/src/repositories/user_repo.rs
@@ -1,6 +1,6 @@
 use argon2::{
-    password_hash::{rand_core::OsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
     Argon2,
+    password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString, rand_core::OsRng},
 };
 use chrono::Utc;
 use rusqlite::OptionalExtension;

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,7 +1,7 @@
 use axum::{
+    Router,
     middleware::from_fn_with_state,
     routing::{get, post},
-    Router,
 };
 
 use crate::handlers::{auth, dashboard, exercises, favicon, health, settings, stats, workouts};

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,5 +1,5 @@
-use axum_extra::extract::cookie::Cookie;
 use axum_extra::extract::CookieJar;
+use axum_extra::extract::cookie::Cookie;
 
 pub const SESSION_COOKIE_NAME: &str = "session";
 

--- a/tests/auth_test.rs
+++ b/tests/auth_test.rs
@@ -2,7 +2,7 @@ mod common;
 
 use axum::{
     body::Body,
-    http::{header, Request, StatusCode},
+    http::{Request, StatusCode, header},
 };
 use http_body_util::BodyExt;
 use liftlog::models::UserRole;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,6 @@
 use axum::Router;
 
-use liftlog::db::{create_memory_pool, DbPool};
+use liftlog::db::{DbPool, create_memory_pool};
 use liftlog::migrations::run_migrations_for_tests;
 use liftlog::models::{User, UserRole};
 use liftlog::repositories::{SessionRepository, UserRepository};

--- a/tests/exercises_test.rs
+++ b/tests/exercises_test.rs
@@ -2,7 +2,7 @@ mod common;
 
 use axum::{
     body::Body,
-    http::{header, Request, StatusCode},
+    http::{Request, StatusCode, header},
 };
 use http_body_util::BodyExt;
 use liftlog::models::UserRole;
@@ -158,7 +158,7 @@ async fn test_edit_exercise_page_renders() {
         .router
         .oneshot(
             Request::builder()
-                .uri(&format!("/exercises/{}/edit", exercise.id))
+                .uri(format!("/exercises/{}/edit", exercise.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),
@@ -190,7 +190,7 @@ async fn test_update_exercise_success() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(&format!("/exercises/{}", exercise.id))
+                .uri(format!("/exercises/{}", exercise.id))
                 .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::from("name=Incline%20Bench%20Press&category=chest"))
@@ -228,7 +228,7 @@ async fn test_delete_exercise_success() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(&format!("/exercises/{}/delete", exercise.id))
+                .uri(format!("/exercises/{}/delete", exercise.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),
@@ -266,7 +266,7 @@ async fn test_cannot_edit_others_exercise() {
         .router
         .oneshot(
             Request::builder()
-                .uri(&format!("/exercises/{}/edit", exercise.id))
+                .uri(format!("/exercises/{}/edit", exercise.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),
@@ -295,7 +295,7 @@ async fn test_cannot_update_others_exercise() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(&format!("/exercises/{}", exercise.id))
+                .uri(format!("/exercises/{}", exercise.id))
                 .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::from("name=Hacked&category=chest"))
@@ -334,7 +334,7 @@ async fn test_cannot_delete_others_exercise() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(&format!("/exercises/{}/delete", exercise.id))
+                .uri(format!("/exercises/{}/delete", exercise.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),
@@ -477,7 +477,7 @@ async fn test_update_exercise_empty_name_rejected() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(&format!("/exercises/{}", exercise.id))
+                .uri(format!("/exercises/{}", exercise.id))
                 .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::from("name=&category=chest"))

--- a/tests/role_permissions_test.rs
+++ b/tests/role_permissions_test.rs
@@ -2,7 +2,7 @@ mod common;
 
 use axum::{
     body::Body,
-    http::{header, Request, StatusCode},
+    http::{Request, StatusCode, header},
 };
 use http_body_util::BodyExt;
 use liftlog::models::UserRole;
@@ -135,7 +135,7 @@ async fn test_admin_can_delete_user() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(&format!("/users/{}/delete", user.id))
+                .uri(format!("/users/{}/delete", user.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),
@@ -170,7 +170,7 @@ async fn test_user_cannot_delete_user() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(&format!("/users/{}/delete", user2.id))
+                .uri(format!("/users/{}/delete", user2.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),
@@ -203,7 +203,7 @@ async fn test_admin_cannot_self_delete() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(&format!("/users/{}/delete", admin.id))
+                .uri(format!("/users/{}/delete", admin.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),
@@ -237,7 +237,7 @@ async fn test_admin_can_promote_user() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(&format!("/users/{}/promote", user.id))
+                .uri(format!("/users/{}/promote", user.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),
@@ -272,7 +272,7 @@ async fn test_user_cannot_promote_user() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(&format!("/users/{}/promote", user2.id))
+                .uri(format!("/users/{}/promote", user2.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),

--- a/tests/settings_test.rs
+++ b/tests/settings_test.rs
@@ -2,7 +2,7 @@ mod common;
 
 use axum::{
     body::Body,
-    http::{header, Request, StatusCode},
+    http::{Request, StatusCode, header},
 };
 use http_body_util::BodyExt;
 use liftlog::models::UserRole;

--- a/tests/stats_test.rs
+++ b/tests/stats_test.rs
@@ -2,7 +2,7 @@ mod common;
 
 use axum::{
     body::Body,
-    http::{header, Request, StatusCode},
+    http::{Request, StatusCode, header},
 };
 use http_body_util::BodyExt;
 use liftlog::models::UserRole;
@@ -200,7 +200,7 @@ async fn test_exercise_stats_shows_history() {
         .router
         .oneshot(
             Request::builder()
-                .uri(&format!("/stats/exercise/{}", exercise.id))
+                .uri(format!("/stats/exercise/{}", exercise.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),
@@ -306,7 +306,7 @@ async fn test_exercise_stats_chart_renders_with_two_or_more_sessions() {
         .router
         .oneshot(
             Request::builder()
-                .uri(&format!("/stats/exercise/{}", exercise.id))
+                .uri(format!("/stats/exercise/{}", exercise.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),
@@ -362,7 +362,7 @@ async fn test_exercise_stats_chart_renders_sparse_state_with_one_session() {
         .router
         .oneshot(
             Request::builder()
-                .uri(&format!("/stats/exercise/{}", exercise.id))
+                .uri(format!("/stats/exercise/{}", exercise.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),
@@ -394,7 +394,7 @@ async fn test_exercise_stats_chart_renders_empty_state_with_no_logs() {
         .router
         .oneshot(
             Request::builder()
-                .uri(&format!("/stats/exercise/{}", exercise.id))
+                .uri(format!("/stats/exercise/{}", exercise.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),
@@ -436,7 +436,7 @@ async fn test_exercise_stats_chart_pr_dots_match_expected_indices() {
         .router
         .oneshot(
             Request::builder()
-                .uri(&format!("/stats/exercise/{}", exercise.id))
+                .uri(format!("/stats/exercise/{}", exercise.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),

--- a/tests/workout_share_test.rs
+++ b/tests/workout_share_test.rs
@@ -2,7 +2,7 @@ mod common;
 
 use axum::{
     body::Body,
-    http::{header, Request, StatusCode},
+    http::{Request, StatusCode, header},
 };
 use http_body_util::BodyExt;
 use liftlog::models::UserRole;
@@ -31,7 +31,7 @@ async fn test_share_workout_success() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(&format!("/workouts/{}/share", workout.id))
+                .uri(format!("/workouts/{}/share", workout.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),
@@ -41,13 +41,15 @@ async fn test_share_workout_success() {
 
     // Should redirect to workout page
     assert_eq!(response.status(), StatusCode::SEE_OTHER);
-    assert!(response
-        .headers()
-        .get("location")
-        .unwrap()
-        .to_str()
-        .unwrap()
-        .contains(&workout.id));
+    assert!(
+        response
+            .headers()
+            .get("location")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .contains(&workout.id)
+    );
 
     // Verify share_token was set
     let workout_repo = WorkoutRepository::new(pool);
@@ -87,7 +89,7 @@ async fn test_view_shared_workout_public() {
     let response = app
         .oneshot(
             Request::builder()
-                .uri(&format!("/shared/{}", share_token))
+                .uri(format!("/shared/{}", share_token))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -153,7 +155,7 @@ async fn test_revoke_share_success() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(&format!("/workouts/{}/revoke-share", workout.id))
+                .uri(format!("/workouts/{}/revoke-share", workout.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),
@@ -176,7 +178,7 @@ async fn test_revoke_share_success() {
     let response = app
         .oneshot(
             Request::builder()
-                .uri(&format!("/shared/{}", share_token))
+                .uri(format!("/shared/{}", share_token))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -227,7 +229,7 @@ async fn test_reshare_after_revoke_generates_new_token() {
     let response = app
         .oneshot(
             Request::builder()
-                .uri(&format!("/shared/{}", token1))
+                .uri(format!("/shared/{}", token1))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -240,7 +242,7 @@ async fn test_reshare_after_revoke_generates_new_token() {
     let response2 = app2
         .oneshot(
             Request::builder()
-                .uri(&format!("/shared/{}", token2))
+                .uri(format!("/shared/{}", token2))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -275,7 +277,7 @@ async fn test_cannot_share_others_workout() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(&format!("/workouts/{}/share", workout.id))
+                .uri(format!("/workouts/{}/share", workout.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),
@@ -313,7 +315,7 @@ async fn test_share_requires_auth() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(&format!("/workouts/{}/share", workout.id))
+                .uri(format!("/workouts/{}/share", workout.id))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -343,7 +345,7 @@ async fn test_revoke_share_requires_auth() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(&format!("/workouts/{}/revoke-share", workout.id))
+                .uri(format!("/workouts/{}/revoke-share", workout.id))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -386,7 +388,7 @@ async fn test_cannot_revoke_others_share() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(&format!("/workouts/{}/revoke-share", workout.id))
+                .uri(format!("/workouts/{}/revoke-share", workout.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),
@@ -426,7 +428,7 @@ async fn test_show_workout_displays_share_button() {
         .router
         .oneshot(
             Request::builder()
-                .uri(&format!("/workouts/{}", workout.id))
+                .uri(format!("/workouts/{}", workout.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),
@@ -474,7 +476,7 @@ async fn test_show_workout_displays_share_link_and_revoke() {
         .router
         .oneshot(
             Request::builder()
-                .uri(&format!("/workouts/{}", workout.id))
+                .uri(format!("/workouts/{}", workout.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),

--- a/tests/workout_test.rs
+++ b/tests/workout_test.rs
@@ -2,7 +2,7 @@ mod common;
 
 use axum::{
     body::Body,
-    http::{header, Request, StatusCode},
+    http::{Request, StatusCode, header},
 };
 use http_body_util::BodyExt;
 use liftlog::models::UserRole;
@@ -218,7 +218,7 @@ async fn test_delete_workout() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(&format!("/workouts/{}/delete", workout.id))
+                .uri(format!("/workouts/{}/delete", workout.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),
@@ -264,7 +264,7 @@ async fn test_cannot_delete_others_workout() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(&format!("/workouts/{}/delete", workout.id))
+                .uri(format!("/workouts/{}/delete", workout.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),
@@ -304,7 +304,7 @@ async fn test_view_workout_details() {
         .router
         .oneshot(
             Request::builder()
-                .uri(&format!("/workouts/{}", workout.id))
+                .uri(format!("/workouts/{}", workout.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),
@@ -348,7 +348,7 @@ async fn test_cannot_view_others_workout() {
         .router
         .oneshot(
             Request::builder()
-                .uri(&format!("/workouts/{}", workout.id))
+                .uri(format!("/workouts/{}", workout.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),
@@ -385,7 +385,7 @@ async fn test_edit_workout_page_renders() {
         .router
         .oneshot(
             Request::builder()
-                .uri(&format!("/workouts/{}/edit", workout.id))
+                .uri(format!("/workouts/{}/edit", workout.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),
@@ -425,7 +425,7 @@ async fn test_update_workout_success() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(&format!("/workouts/{}", workout.id))
+                .uri(format!("/workouts/{}", workout.id))
                 .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::from("date=2024-01-20&notes=Updated%20notes"))
@@ -474,7 +474,7 @@ async fn test_cannot_edit_others_workout_page() {
         .router
         .oneshot(
             Request::builder()
-                .uri(&format!("/workouts/{}/edit", workout.id))
+                .uri(format!("/workouts/{}/edit", workout.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),
@@ -510,7 +510,7 @@ async fn test_add_log_success() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(&format!("/workouts/{}/logs", workout.id))
+                .uri(format!("/workouts/{}/logs", workout.id))
                 .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::from(format!(
@@ -523,13 +523,15 @@ async fn test_add_log_success() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::SEE_OTHER);
-    assert!(response
-        .headers()
-        .get("location")
-        .unwrap()
-        .to_str()
-        .unwrap()
-        .contains(&workout.id));
+    assert!(
+        response
+            .headers()
+            .get("location")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .contains(&workout.id)
+    );
 
     // Verify log was created
     let workout_repo = WorkoutRepository::new(pool);
@@ -565,7 +567,7 @@ async fn test_add_log_accepts_fractional_weight() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(&format!("/workouts/{}/logs", workout.id))
+                .uri(format!("/workouts/{}/logs", workout.id))
                 .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::from(format!(
@@ -613,7 +615,7 @@ async fn test_add_log_requires_ownership() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(&format!("/workouts/{}/logs", workout.id))
+                .uri(format!("/workouts/{}/logs", workout.id))
                 .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::from(format!(
@@ -652,7 +654,7 @@ async fn test_delete_log_success() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(&format!("/workouts/{}/logs/{}/delete", workout.id, log.id))
+                .uri(format!("/workouts/{}/logs/{}/delete", workout.id, log.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),
@@ -697,7 +699,7 @@ async fn test_delete_log_requires_ownership() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(&format!("/workouts/{}/logs/{}/delete", workout.id, log.id))
+                .uri(format!("/workouts/{}/logs/{}/delete", workout.id, log.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),
@@ -739,7 +741,7 @@ async fn test_edit_log_page_renders() {
         .router
         .oneshot(
             Request::builder()
-                .uri(&format!("/workouts/{}/logs/{}/edit", workout.id, log.id))
+                .uri(format!("/workouts/{}/logs/{}/edit", workout.id, log.id))
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::empty())
                 .unwrap(),
@@ -780,7 +782,7 @@ async fn test_update_log_success() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(&format!("/workouts/{}/logs/{}", workout.id, log.id))
+                .uri(format!("/workouts/{}/logs/{}", workout.id, log.id))
                 .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::from("reps=12&weight=110&rpe=9"))
@@ -823,7 +825,7 @@ async fn test_update_log_accepts_fractional_weight() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(&format!("/workouts/{}/logs/{}", workout.id, log.id))
+                .uri(format!("/workouts/{}/logs/{}", workout.id, log.id))
                 .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::from("reps=10&weight=21.25&rpe=8"))
@@ -865,7 +867,7 @@ async fn test_update_log_requires_ownership() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(&format!("/workouts/{}/logs/{}", workout.id, log.id))
+                .uri(format!("/workouts/{}/logs/{}", workout.id, log.id))
                 .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
                 .header(header::COOKIE, &cookie_header)
                 .body(Body::from("reps=12&weight=110&rpe=9"))


### PR DESCRIPTION
## What

- **Bump pinned toolchain** `rust-toolchain.toml` 1.94.0 → 1.96.0 and **migrate
  to Rust 2024 edition** (2021 → 2024), aligning with the other projects. Code
  changes are the mechanical output of `cargo fix --edition` + `cargo clippy
  --fix`; no behavioral changes intended.
- Add `deny.toml` (advisories / licenses / bans / sources) and a `cargo-deny` CI
  job, matching the other Rust projects.
- Replace the hand-rolled `actions/cache` blocks with `Swatinem/rust-cache`
  (SHA-pinned `v2.9.1`); the Playwright browser cache is left as-is.

Per the repo convention, `MSRV` (`rust-version`) is unset and is left untouched.

## Security advisories surfaced by cargo-deny

Fixed via `Cargo.lock`: `rand` → 0.10.1.

Documented in `deny.toml`'s ignore list:
- `RUSTSEC-2026-0186` — memmap2; fixed in 0.9.11, but that release is younger
  than the 7-day dependency cooldown. **Re-bump and drop the ignore once it ages
  out.**

## Verification

`cargo fmt --all -- --check`, `cargo clippy -- -D warnings`, `cargo deny check`,
and `cargo nextest run` (284 passed) all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)