### PR TITLE
build: ship a static musl image and switch to mimalloc

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,8 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
-
+      # No qemu: the Dockerfile builder is pinned to the native platform and zig
+      # cross-compiles both musl targets, so the arm64 image needs no emulation.
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,6 +847,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,6 +879,7 @@ dependencies = [
  "dotenvy",
  "http",
  "http-body-util",
+ "mimalloc",
  "r2d2",
  "r2d2_sqlite",
  "rand_core 0.6.4",
@@ -930,6 +940,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 dotenvy = "0.15"
 thiserror = "2"
 anyhow = "1"
+mimalloc = "0.1"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,71 +1,60 @@
-# Stage 1: Chef - prepare recipe (runs on build platform)
-FROM --platform=$BUILDPLATFORM rust:1.96-bookworm AS chef
-RUN cargo install cargo-chef
+# syntax=docker/dockerfile:1
+
+# ---- build: cross-compile a static musl binary with cargo-zigbuild ----------
+# The builder is pinned to the native build platform; zig cross-compiles to the
+# target arch's musl triple, so no qemu emulation is needed — an arm64 image
+# builds at the host's native speed. The only C dependencies are the bundled
+# SQLite and mimalloc, both compiled by zig cc; the favicon renderer (resvg) is
+# pure Rust, so no CMake or system libraries are required.
+FROM --platform=$BUILDPLATFORM rust:1.96-bookworm AS build
+
+# curl + xz fetch zig; that is the only build-time system dependency.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Zig 0.14.1 avoids the libc++-19 bindgen requirement that 0.15+ introduces.
+ARG ZIG_VERSION=0.14.1
+ARG ZIGBUILD_VERSION=0.22.3
+RUN cargo install cargo-zigbuild --version "${ZIGBUILD_VERSION}" --locked
+RUN set -eux; \
+    case "$(uname -m)" in \
+      x86_64) zarch=x86_64 ;; \
+      aarch64) zarch=aarch64 ;; \
+      *) echo "unsupported build arch $(uname -m)" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-${zarch}-linux-${ZIG_VERSION}.tar.xz" \
+      | tar -xJ -C /opt; \
+    ln -s "/opt/zig-${zarch}-linux-${ZIG_VERSION}/zig" /usr/local/bin/zig
+
 WORKDIR /app
-
-# Stage 2: Planner - create recipe.json
-FROM chef AS planner
 COPY . .
-RUN cargo chef prepare --recipe-path recipe.json
 
-# Stage 3: Builder - cross-compile for target platform
-FROM chef AS builder
-
-# Target platform args (set by docker buildx)
-ARG TARGETPLATFORM
+# Map Docker's TARGETARCH onto the Rust musl triple and build. `rustup target
+# add` runs after the source (and rust-toolchain.toml) is in place, so it
+# resolves against the pinned toolchain rather than the base image's default.
+# .git is excluded by .dockerignore, so build.rs reads the version from the
+# GIT_VERSION build arg the CI workflow passes.
+ARG TARGETARCH
 ARG GIT_VERSION=dev
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/app/target,sharing=locked \
+    set -eux; \
+    case "$TARGETARCH" in \
+      amd64) target=x86_64-unknown-linux-musl ;; \
+      arm64) target=aarch64-unknown-linux-musl ;; \
+      *) echo "unsupported target arch $TARGETARCH" >&2; exit 1 ;; \
+    esac; \
+    rustup target add "$target"; \
+    GIT_VERSION="${GIT_VERSION}" cargo zigbuild --release --target "$target"; \
+    install -Dm755 "target/${target}/release/liftlog" /out/liftlog
 
-# Copy the toolchain pin BEFORE any rustup invocation so that rustup resolves
-# against the pinned toolchain (rust-toolchain.toml) rather than whatever patch
-# version the base image happens to ship. Without this the base image's default
-# toolchain gets the cross-compile target installed, and then `cargo build`
-# downloads the pinned toolchain fresh (without the target) and fails.
-COPY rust-toolchain.toml .
-
-# Install cross-compilation toolchain based on target
-RUN case "$TARGETPLATFORM" in \
-        "linux/arm64") \
-            apt-get update && apt-get install -y gcc-aarch64-linux-gnu && \
-            rustup target add aarch64-unknown-linux-gnu \
-            ;; \
-        "linux/amd64") \
-            # Native build, no extra toolchain needed \
-            ;; \
-    esac
-
-# Configure cargo for cross-compilation
-RUN mkdir -p .cargo && \
-    case "$TARGETPLATFORM" in \
-        "linux/arm64") \
-            echo '[target.aarch64-unknown-linux-gnu]' >> .cargo/config.toml && \
-            echo 'linker = "aarch64-linux-gnu-gcc"' >> .cargo/config.toml \
-            ;; \
-    esac
-
-# Set the Rust target based on platform
-RUN case "$TARGETPLATFORM" in \
-        "linux/arm64") echo "aarch64-unknown-linux-gnu" > /tmp/rust_target ;; \
-        "linux/amd64") echo "x86_64-unknown-linux-gnu" > /tmp/rust_target ;; \
-        *) echo "x86_64-unknown-linux-gnu" > /tmp/rust_target ;; \
-    esac
-
-COPY --from=planner /app/recipe.json recipe.json
-
-# Cook dependencies with target
-RUN RUST_TARGET=$(cat /tmp/rust_target) && \
-    cargo chef cook --release --recipe-path recipe.json --target $RUST_TARGET
-
-COPY . .
-
-# Build the application
-RUN RUST_TARGET=$(cat /tmp/rust_target) && \
-    GIT_VERSION=${GIT_VERSION} cargo build --release --target $RUST_TARGET && \
-    cp target/$RUST_TARGET/release/liftlog /app/liftlog
-
-# Stage 4: Runtime
-FROM gcr.io/distroless/cc-debian12
-
-COPY --from=builder /app/liftlog /liftlog
+# ---- runtime: minimal static image (CA certs + tzdata, no shell) ------------
+# distroless/static (not :nonroot) keeps the root runtime user the previous
+# distroless/cc image defaulted to, so the bind-mounted /data SQLite file stays
+# writable without a permissions change.
+FROM gcr.io/distroless/static-debian12
+COPY --from=build /out/liftlog /liftlog
 
 VOLUME /data
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,12 @@ use migrations::run_migrations;
 use repositories::{ExerciseRepository, SessionRepository, UserRepository, WorkoutRepository};
 use state::AppState;
 
+// The release image links musl, whose default allocator is markedly slower than
+// glibc's under concurrent load. mimalloc restores throughput for the request
+// handlers and the r2d2 SQLite pool.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // Initialize tracing


### PR DESCRIPTION
## What

Migrate the release image from a glibc dynamic build to a fully static
musl binary, and add mimalloc as the global allocator — matching the
approach already shipped for `lur`, `comics` and `noadd`.

## Changes

- **Dockerfile**: replace the `cargo-chef` + glibc cross-build with
  `cargo-zigbuild` targeting `x86_64`/`aarch64-unknown-linux-musl`, and run
  on `distroless/static-debian12` instead of `distroless/cc-debian12`. zig
  cross-compiles both arches from the native builder — the only C deps are
  the bundled SQLite and mimalloc (both via zig cc); resvg is pure Rust, so
  no CMake or system libraries are required. The runtime image is fully
  static.
- The runtime stays on `distroless/static` (root, not `:nonroot`) so the
  `/data` SQLite file stays writable without a permissions change.
- **`.github/workflows/docker.yml`**: drop `setup-qemu-action` — zig
  cross-compiles, so no emulation is needed. Existing GHA layer cache kept.
- **mimalloc**: added as the global allocator to recover the throughput
  musl's default allocator loses under concurrent request and r2d2
  connection-pool load.

## Verification

- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- Docker build succeeds for both `linux/amd64` and `linux/arm64`; both
  binaries are `statically linked, stripped`.
- Ran the arm64 image: SQLite migrations apply on boot, the server starts,
  `GET /` 303-redirects to `/auth/login`, and `/auth/setup` returns `200` —
  all from the no-libc `distroless/static` base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)