### PR TITLE
ci: tidy docker workflow whitespace

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,17 +13,14 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
       # No qemu: the Dockerfile builder is pinned to the native platform and zig
       # cross-compiles both musl targets, so the arm64 image needs no emulation.
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-
       - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       - uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         id: meta
         with:
@@ -32,11 +29,9 @@ jobs:
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-
       - name: Get version
         id: version
         run: echo "version=$(git describe --tags --always --dirty)" >> $GITHUB_OUTPUT
-
       - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .


### PR DESCRIPTION
Drop the blank lines between steps in the Docker workflow — each step already
begins with its own `- uses:`/`- name:` marker, so the separators add nothing.
Top-level block separators are kept. No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)