### PR TITLE
chore(deps): ignore unmaintained ttf-parser advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "argon2"

--- a/deny.toml
+++ b/deny.toml
@@ -16,6 +16,12 @@ ignore = [
     # release is younger than our 7-day dependency cooldown — re-bump and drop
     # this entry once it has aged out.
     "RUSTSEC-2026-0186",
+    # ttf-parser is unmaintained (author will not ship further fixes). It is a
+    # build-time-only dependency, pulled in transitively through
+    # resvg → usvg → fontdb/rustybuzz to render the app icon in build.rs, and
+    # never reaches the running server. No safe upgrade exists yet (resvg has
+    # not migrated to skrifa) — drop this entry once resvg replaces ttf-parser.
+    "RUSTSEC-2026-0192",
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

`cargo deny check` started failing on every push and PR after **RUSTSEC-2026-0192** landed: `ttf-parser` is now flagged as unmaintained. This blocks unrelated dependency PRs (e.g. #111, #112) since the advisory scan runs over the whole `Cargo.lock`.

`ttf-parser` is a **build-time-only** dependency — it is pulled in transitively through `resvg → usvg → fontdb`/`rustybuzz` to render the app icon in `build.rs`, and never reaches the running server:

```
ttf-parser v0.25.1
├── fontdb → usvg → resvg → (build) liftlog
├── rustybuzz → usvg
└── usvg
```

There is **no safe upgrade** yet (the advisory notes `resvg` has not migrated to `skrifa`). This PR adds `RUSTSEC-2026-0192` to the `[advisories] ignore` list in `deny.toml`, with a comment to drop it once `resvg` replaces `ttf-parser`.

## Verification

- `cargo deny check advisories` no longer reports `ttf-parser`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)