### PR TITLE
chore(deps): update memmap2 to 0.9.11 and drop advisory ignore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,9 +935,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -12,10 +12,6 @@ version = 2
 # `ignore` holds advisory IDs we've reviewed and consciously accept (none yet).
 yanked = "deny"
 ignore = [
-    # memmap2 unchecked pointer offset (unsound). Fixed in 0.9.11, but that
-    # release is younger than our 7-day dependency cooldown — re-bump and drop
-    # this entry once it has aged out.
-    "RUSTSEC-2026-0186",
     # ttf-parser is unmaintained (author will not ship further fixes). It is a
     # build-time-only dependency, pulled in transitively through
     # resvg → usvg → fontdb/rustybuzz to render the app icon in build.rs, and


### PR DESCRIPTION
## Summary

`RUSTSEC-2026-0186` (unchecked pointer offset, unsound) in `memmap2` was previously ignored in `deny.toml` because the fixed release (0.9.11) was younger than the project's 7-day dependency cooldown. It has now aged past that cooldown (published 2026-06-22), so this PR bumps `memmap2` and drops the ignore entry.

`memmap2` is a build-time-only transitive dependency, pulled in via `fontdb → usvg → resvg` to render the app icon in `build.rs`.

## Verification

- `cargo deny check` passes with no ignore entry needed for `RUSTSEC-2026-0186`.
- `cargo fmt --all -- --check` passes.
- `cargo nextest run`: 284/284 tests pass.