### PR TITLE
chore(deps): pin time to 0.3.53 to keep cookie 0.18.1 compiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,9 +1649,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "num-conv",
@@ -1669,9 +1669,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,11 @@ edition = "2024"
 axum = { version = "0.8", features = ["macros"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal", "sync"] }
 askama = "0.16"
-time = "0.3"
+# Pinned: time 0.3.52 changed a sealed-trait internal API and broke cookie 0.18.1
+# (build failure in #118). 0.3.53 restores compilation via a deprecated shim that
+# time says it will remove — so 0.3.54+ is expected to break cookie again until it
+# ships a fix. Hold at 0.3.53 until cookie 0.18.x adapts.
+time = ">=0.3.53, <0.3.54"
 rusqlite = { version = "0.32", features = ["bundled", "chrono"] }
 r2d2 = "0.8"
 r2d2_sqlite = "0.25"


### PR DESCRIPTION
## What

Constrain `time` to `>=0.3.53, <0.3.54` and update the lockfile to 0.3.53.

## Why

`time` 0.3.52 added a second argument to the sealed `Parsable` trait's internal `parse` method. `cookie` 0.18.1 calls the old single-argument form, so it fails to compile (`E0061`) — this is the build failure seen in #118, which bumped `time` to 0.3.52.

`time` 0.3.53 restores compilation through a `#[deprecated]` compatibility shim, but its changelog states the shim **will be removed** in a future release and that its removal **will not be treated as a breaking change**. So a future `0.3.54` is expected to break `cookie` again until `cookie` ships a fix.

The upper bound (`<0.3.54`) prevents Dependabot from pulling in either the broken 0.3.52 or a future 0.3.54 that re-breaks the build before `cookie` adapts. The rationale is also captured as a comment in `Cargo.toml`.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo build` — `cookie 0.18.1` compiles against `time 0.3.53`
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo nextest run` — 284 passed
- `cargo deny check` — advisories/bans/licenses/sources ok

Supersedes and closes #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)