### PR TITLE
feat(config): replace HOST/PORT with a single BIND socket address

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ LiftLog is a self-hosted workout journal: an Axum + Askama server-rendered app b
 ## Commands
 
 ```bash
-cargo run                                 # dev server on $PORT (default 3000)
+cargo run                                 # dev server on $BIND (default 0.0.0.0:8080)
 cargo fmt --all -- --check                # formatting gate
 cargo clippy --all-targets -- -D warnings # lint gate
 cargo deny check                          # supply-chain gate (advisories/licenses/bans/sources)

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,8 +59,8 @@ COPY --from=build /out/liftlog /liftlog
 VOLUME /data
 
 ENV DATABASE_URL=/data/liftlog.sqlite3
-ENV SERVER_PORT=3000
+ENV BIND=0.0.0.0:8080
 
-EXPOSE 3000
+EXPOSE 8080
 
 ENTRYPOINT ["/liftlog"]

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ Track your training sessions, monitor progress, and celebrate personal records.
 ```bash
 docker run -d \
   --name liftlog \
-  -p 3000:3000 \
+  -p 8080:8080 \
   -v liftlog_data:/data \
   ghcr.io/henry40408/liftlog:latest
 ```
 
-Visit `http://localhost:3000` and create your account.
+Visit `http://localhost:8080` and create your account.
 
 ### Building from Source
 
@@ -58,8 +58,7 @@ All configuration is done via environment variables:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DATABASE_URL` | `sqlite:liftlog.sqlite3?mode=rwc` | SQLite database connection string |
-| `HOST` | `0.0.0.0` | Server bind address |
-| `PORT` | `3000` | HTTP server port |
+| `BIND` | `0.0.0.0:8080` | HTTP server bind address (`host:port`) |
 | `RUST_LOG` | `error,liftlog=info` | Log level filter |
 | `LOG_FORMAT` | `full` | Log output format: `full`, `compact`, `pretty`, `json` (also settable via `--log-format`) |
 
@@ -72,7 +71,7 @@ services:
   liftlog:
     image: ghcr.io/henry40408/liftlog:latest
     ports:
-      - "3000:3000"
+      - "8080:8080"
     volumes:
       - liftlog_data:/data
     restart: unless-stopped

--- a/deny.toml
+++ b/deny.toml
@@ -18,6 +18,10 @@ ignore = [
     # never reaches the running server. No safe upgrade exists yet (resvg has
     # not migrated to skrifa) — drop this entry once resvg replaces ttf-parser.
     "RUSTSEC-2026-0192",
+    # rustybuzz is unmaintained — same build-time-only resvg → usvg → rustybuzz
+    # chain (text shaping for the build.rs app-icon render), never reaching the
+    # running server. Drop once resvg migrates off rustybuzz.
+    "RUSTSEC-2026-0206",
 ]
 
 [licenses]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,26 +1,85 @@
 use std::env;
+use std::net::SocketAddr;
 
 #[derive(Clone)]
 pub struct Config {
     pub database_url: String,
-    pub host: String,
-    pub port: u16,
+    pub bind: SocketAddr,
 }
 
 impl Config {
-    pub fn from_env() -> Result<Self, env::VarError> {
+    pub fn from_env() -> anyhow::Result<Self> {
         Ok(Self {
             database_url: env::var("DATABASE_URL")
                 .unwrap_or_else(|_| "sqlite:liftlog.sqlite3?mode=rwc".to_string()),
-            host: env::var("HOST").unwrap_or_else(|_| "0.0.0.0".to_string()),
-            port: env::var("PORT")
-                .unwrap_or_else(|_| "3000".to_string())
-                .parse()
-                .unwrap_or(3000),
+            bind: parse_bind(env::var("BIND").ok().as_deref()).map_err(anyhow::Error::msg)?,
         })
     }
+}
 
-    pub fn server_addr(&self) -> String {
-        format!("{}:{}", self.host, self.port)
+/// Resolve the `BIND` value into a [`SocketAddr`]. An unset or empty value
+/// yields the default `0.0.0.0:8080` (listen on all interfaces, so a reverse
+/// proxy in a separate container can reach it); any non-empty value must be a
+/// valid `host:port` socket address.
+pub fn parse_bind(raw: Option<&str>) -> Result<SocketAddr, String> {
+    match raw {
+        Some(v) if !v.is_empty() => v
+            .parse::<SocketAddr>()
+            .map_err(|e| format!("invalid BIND '{v}': {e}")),
+        _ => Ok(SocketAddr::from(([0, 0, 0, 0], 8080))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::SocketAddr;
+
+    #[test]
+    fn parse_bind_defaults_when_absent_or_empty() {
+        // Unset or empty → default 0.0.0.0:8080 (all interfaces).
+        assert_eq!(
+            parse_bind(None).unwrap(),
+            SocketAddr::from(([0, 0, 0, 0], 8080))
+        );
+        assert_eq!(
+            parse_bind(Some("")).unwrap(),
+            SocketAddr::from(([0, 0, 0, 0], 8080))
+        );
+    }
+
+    #[test]
+    fn parse_bind_accepts_valid_socket_addr() {
+        // A valid host:port is honored, incl. a loopback-only bind.
+        assert_eq!(
+            parse_bind(Some("127.0.0.1:9000")).unwrap(),
+            "127.0.0.1:9000".parse().unwrap()
+        );
+        assert_eq!(
+            parse_bind(Some("0.0.0.0:8080")).unwrap(),
+            "0.0.0.0:8080".parse().unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_bind_rejects_invalid() {
+        // Invalid input fails with a descriptive error; a bare host with no
+        // port is not a SocketAddr.
+        let err = parse_bind(Some("not-an-addr")).unwrap_err();
+        assert!(err.contains("invalid BIND"), "got: {err}");
+        assert!(parse_bind(Some("127.0.0.1")).is_err());
+    }
+
+    #[test]
+    fn from_env_reads_bind() {
+        // nextest runs each test in its own process, so mutating the
+        // environment here does not leak into other tests. `set_var` is
+        // `unsafe` under edition 2024.
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::set_var("BIND", "127.0.0.1:9137");
+        }
+        let config = Config::from_env().expect("from_env should succeed");
+        assert_eq!(config.bind, "127.0.0.1:9137".parse().unwrap());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,10 +129,10 @@ async fn main() -> anyhow::Result<()> {
     let app = routes::create_router(app_state);
 
     // Start server
-    let addr = config.server_addr();
+    let addr = config.bind;
     tracing::info!("Starting server at http://{}", addr);
 
-    let listener = TcpListener::bind(&addr).await?;
+    let listener = TcpListener::bind(addr).await?;
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal())
         .await?;

--- a/tests/e2e/steps/fixtures.js
+++ b/tests/e2e/steps/fixtures.js
@@ -50,8 +50,7 @@ export const test = base.extend({
         env: {
           ...process.env,
           DATABASE_URL: `sqlite:${dbRel}?mode=rwc`,
-          HOST: '127.0.0.1',
-          PORT: String(port),
+          BIND: `127.0.0.1:${port}`,
           RUST_LOG: 'liftlog=warn',
         },
         stdio: ['ignore', 'pipe', 'pipe'],


### PR DESCRIPTION
## Summary

Merges the separate `HOST` and `PORT` environment variables into a single `BIND` socket address (default `0.0.0.0:8080`), matching the sibling services' bind-address configuration.

The default port also moves from `3000` to `8080` to avoid collisions with frontend dev servers that conventionally occupy port `3000`.

## Behavior

- `BIND=0.0.0.0:8080` (default) — listen on all interfaces; reachable by a reverse proxy in a separate container.
- `BIND=127.0.0.1:8080` — restrict to loopback.
- An invalid `BIND` now fails fast with a clear `invalid BIND '<value>': ...` error.

## Changes

- `src/config.rs` — `host: String` + `port: u16` → `bind: SocketAddr`; new pure `parse_bind` helper with unit tests (default / valid / invalid) plus a `from_env` test
- `src/main.rs` — bind the `SocketAddr` directly (drops `server_addr()`)
- `Dockerfile` — `ENV BIND=0.0.0.0:8080`, `EXPOSE 8080`. Note: the old `ENV SERVER_PORT=3000` was a no-op — the app reads `PORT`, not `SERVER_PORT` — so the container port was never actually configurable; this fixes it.
- `README.md` — env-var table, Docker `-p` mapping, compose `ports`, and "Visit localhost" URL
- `tests/e2e/steps/fixtures.js` — per-worker server boots via `BIND`
- `deny.toml` — ignore `RUSTSEC-2026-0206` (rustybuzz unmaintained). Unrelated to the bind change: a new advisory surfaced on CI against a build-time-only crate pulled through the same `resvg → usvg` icon-render chain as the already-accepted `ttf-parser` (`RUSTSEC-2026-0192`); it never reaches the running server. Included here to unblock this PR's `deny` gate.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo nextest run` (config: 8 passed), `cargo deny check advisories`
- End-to-end smoke test: `BIND=127.0.0.1:18081` → server listens on `127.0.0.1:18081` (confirmed via `lsof`), `curl` returns `303`; invalid `BIND` exits `1` with a clear error.

## BREAKING CHANGE

`HOST` and `PORT` are removed. Use `BIND=0.0.0.0:<port>` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)