### PR TITLE
fix(config): default BIND to loopback (127.0.0.1:8080)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ LiftLog is a self-hosted workout journal: an Axum + Askama server-rendered app b
 ## Commands
 
 ```bash
-cargo run                                 # dev server on $BIND (default 0.0.0.0:8080)
+cargo run                                 # dev server on $BIND (default 127.0.0.1:8080)
 cargo fmt --all -- --check                # formatting gate
 cargo clippy --all-targets -- -D warnings # lint gate
 cargo deny check                          # supply-chain gate (advisories/licenses/bans/sources)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ All configuration is done via environment variables:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DATABASE_URL` | `sqlite:liftlog.sqlite3?mode=rwc` | SQLite database connection string |
-| `BIND` | `0.0.0.0:8080` | HTTP server bind address (`host:port`) |
+| `BIND` | `127.0.0.1:8080` | HTTP server bind address (`host:port`). Defaults to loopback so a bare-metal run is not exposed on all interfaces without opting in; the container image sets `0.0.0.0:8080` so a reverse proxy can reach it. |
 | `RUST_LOG` | `error,liftlog=info` | Log level filter |
 | `LOG_FORMAT` | `full` | Log output format: `full`, `compact`, `pretty`, `json` (also settable via `--log-format`) |
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,15 +18,16 @@ impl Config {
 }
 
 /// Resolve the `BIND` value into a [`SocketAddr`]. An unset or empty value
-/// yields the default `0.0.0.0:8080` (listen on all interfaces, so a reverse
-/// proxy in a separate container can reach it); any non-empty value must be a
-/// valid `host:port` socket address.
+/// yields the default `127.0.0.1:8080` (loopback only, so a bare-metal run is
+/// not exposed on all interfaces without opting in); any non-empty value must
+/// be a valid `host:port` socket address. The container image sets
+/// `BIND=0.0.0.0:8080` so a reverse proxy in a separate container can reach it.
 pub fn parse_bind(raw: Option<&str>) -> Result<SocketAddr, String> {
     match raw {
         Some(v) if !v.is_empty() => v
             .parse::<SocketAddr>()
             .map_err(|e| format!("invalid BIND '{v}': {e}")),
-        _ => Ok(SocketAddr::from(([0, 0, 0, 0], 8080))),
+        _ => Ok(SocketAddr::from(([127, 0, 0, 1], 8080))),
     }
 }
 
@@ -37,14 +38,14 @@ mod tests {
 
     #[test]
     fn parse_bind_defaults_when_absent_or_empty() {
-        // Unset or empty → default 0.0.0.0:8080 (all interfaces).
+        // Unset or empty → default 127.0.0.1:8080 (loopback only).
         assert_eq!(
             parse_bind(None).unwrap(),
-            SocketAddr::from(([0, 0, 0, 0], 8080))
+            SocketAddr::from(([127, 0, 0, 1], 8080))
         );
         assert_eq!(
             parse_bind(Some("")).unwrap(),
-            SocketAddr::from(([0, 0, 0, 0], 8080))
+            SocketAddr::from(([127, 0, 0, 1], 8080))
         );
     }
 


### PR DESCRIPTION
## What

Change the compile-time default of `BIND` from `0.0.0.0:8080` to `127.0.0.1:8080` (loopback only).

## Why

The previous default bound all interfaces. A bare-metal run with nothing configured would listen on `0.0.0.0` — exposed to the network without a firewall. Binding loopback by default is secure-by-default; exposing on all interfaces now requires an explicit opt-in.

Container deployments are unaffected: the `Dockerfile` already sets `ENV BIND=0.0.0.0:8080`, and that env value is overridable at runtime via `docker run -e` or a compose `environment:` entry, so a reverse proxy in a separate container can still reach the server.

## Changes

- `src/config.rs`: default socket addr `127.0.0.1:8080`; updated unit test + doc comment.
- `README.md`: env table default + note on the container override.
- `CLAUDE.md`: dev-server default note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)