### PR TITLE
chore(deps): group minor and patch dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,13 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
+    groups:
+      cargo:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: docker
     directory: /
@@ -15,6 +22,13 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 5
+    groups:
+      docker:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: github-actions
     directory: /
@@ -23,3 +37,10 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary

Add a per-ecosystem `groups` block (cargo, docker, github-actions) to the Dependabot config so that **minor and patch** updates are bundled into a single PR per ecosystem. **Major** updates stay ungrouped, keeping potentially breaking bumps in their own reviewable PR.

## Why

Without grouping, Dependabot opens one PR per dependency. When several updates in the same ecosystem touch the same file (e.g. multiple `github-actions` bumps editing one workflow), merging the first makes the rest conflict and require a rebase — exactly what happened with #122/#123/#124. Grouping minor/patch updates eliminates that class of merge conflict and reduces PR churn.

## Changes

- `.github/dependabot.yml`: added a `groups` entry to each of the three ecosystems, matching all patterns for `minor` + `patch` update-types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)