### PR TITLE
refactor(config): prefix BIND and LOG_FORMAT env vars with LIFTLOG_

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ LiftLog is a self-hosted workout journal: an Axum + Askama server-rendered app b
 ## Commands
 
 ```bash
-cargo run                                 # dev server on $BIND (default 127.0.0.1:8080)
+cargo run                                 # dev server on $LIFTLOG_BIND (default 127.0.0.1:8080)
 cargo fmt --all -- --check                # formatting gate
 cargo clippy --all-targets -- -D warnings # lint gate
 cargo deny check                          # supply-chain gate (advisories/licenses/bans/sources)

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ COPY --from=build /out/liftlog /liftlog
 VOLUME /data
 
 ENV DATABASE_URL=/data/liftlog.sqlite3
-ENV BIND=0.0.0.0:8080
+ENV LIFTLOG_BIND=0.0.0.0:8080
 
 EXPOSE 8080
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ All configuration is done via environment variables:
 | `RUST_LOG` | `error,liftlog=info` | Log level filter |
 | `LIFTLOG_LOG_FORMAT` | `full` | Log output format: `full`, `compact`, `pretty`, `json` (also settable via `--log-format`) |
 
+> **Migration note:** `BIND` and `LOG_FORMAT` were renamed to `LIFTLOG_BIND` and `LIFTLOG_LOG_FORMAT`. If either old name is still set in the environment, the server **refuses to start** and names the replacement, so a stale value can't be silently ignored.
+
 ## Docker
 
 ### Docker Compose

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ All configuration is done via environment variables:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DATABASE_URL` | `sqlite:liftlog.sqlite3?mode=rwc` | SQLite database connection string |
-| `BIND` | `127.0.0.1:8080` | HTTP server bind address (`host:port`). Defaults to loopback so a bare-metal run is not exposed on all interfaces without opting in; the container image sets `0.0.0.0:8080` so a reverse proxy can reach it. |
+| `LIFTLOG_BIND` | `127.0.0.1:8080` | HTTP server bind address (`host:port`). Defaults to loopback so a bare-metal run is not exposed on all interfaces without opting in; the container image sets `0.0.0.0:8080` so a reverse proxy can reach it. |
 | `RUST_LOG` | `error,liftlog=info` | Log level filter |
-| `LOG_FORMAT` | `full` | Log output format: `full`, `compact`, `pretty`, `json` (also settable via `--log-format`) |
+| `LIFTLOG_LOG_FORMAT` | `full` | Log output format: `full`, `compact`, `pretty`, `json` (also settable via `--log-format`) |
 
 ## Docker
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,21 +12,23 @@ impl Config {
         Ok(Self {
             database_url: env::var("DATABASE_URL")
                 .unwrap_or_else(|_| "sqlite:liftlog.sqlite3?mode=rwc".to_string()),
-            bind: parse_bind(env::var("BIND").ok().as_deref()).map_err(anyhow::Error::msg)?,
+            bind: parse_bind(env::var("LIFTLOG_BIND").ok().as_deref())
+                .map_err(anyhow::Error::msg)?,
         })
     }
 }
 
-/// Resolve the `BIND` value into a [`SocketAddr`]. An unset or empty value
-/// yields the default `127.0.0.1:8080` (loopback only, so a bare-metal run is
-/// not exposed on all interfaces without opting in); any non-empty value must
+/// Resolve the `LIFTLOG_BIND` value into a [`SocketAddr`]. An unset or empty
+/// value yields the default `127.0.0.1:8080` (loopback only, so a bare-metal run
+/// is not exposed on all interfaces without opting in); any non-empty value must
 /// be a valid `host:port` socket address. The container image sets
-/// `BIND=0.0.0.0:8080` so a reverse proxy in a separate container can reach it.
+/// `LIFTLOG_BIND=0.0.0.0:8080` so a reverse proxy in a separate container can
+/// reach it.
 pub fn parse_bind(raw: Option<&str>) -> Result<SocketAddr, String> {
     match raw {
         Some(v) if !v.is_empty() => v
             .parse::<SocketAddr>()
-            .map_err(|e| format!("invalid BIND '{v}': {e}")),
+            .map_err(|e| format!("invalid LIFTLOG_BIND '{v}': {e}")),
         _ => Ok(SocketAddr::from(([127, 0, 0, 1], 8080))),
     }
 }
@@ -67,7 +69,7 @@ mod tests {
         // Invalid input fails with a descriptive error; a bare host with no
         // port is not a SocketAddr.
         let err = parse_bind(Some("not-an-addr")).unwrap_err();
-        assert!(err.contains("invalid BIND"), "got: {err}");
+        assert!(err.contains("invalid LIFTLOG_BIND"), "got: {err}");
         assert!(parse_bind(Some("127.0.0.1")).is_err());
     }
 
@@ -78,7 +80,7 @@ mod tests {
         // `unsafe` under edition 2024.
         #[allow(unsafe_code)]
         unsafe {
-            std::env::set_var("BIND", "127.0.0.1:9137");
+            std::env::set_var("LIFTLOG_BIND", "127.0.0.1:9137");
         }
         let config = Config::from_env().expect("from_env should succeed");
         assert_eq!(config.bind, "127.0.0.1:9137".parse().unwrap());

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,8 +7,36 @@ pub struct Config {
     pub bind: SocketAddr,
 }
 
+/// Env vars that were renamed under the `LIFTLOG_` prefix, paired with their
+/// current name. Old deployments that upgrade without renaming would otherwise
+/// have their value silently ignored; [`reject_legacy_env_vars`] fails startup
+/// so the misconfiguration is visible.
+const RENAMED_ENV_VARS: &[(&str, &str)] = &[
+    ("BIND", "LIFTLOG_BIND"),
+    ("LOG_FORMAT", "LIFTLOG_LOG_FORMAT"),
+];
+
+/// Refuse to start when any pre-prefix env var name is still present, pointing
+/// the operator at its replacement.
+pub fn reject_legacy_env_vars() -> anyhow::Result<()> {
+    let stale: Vec<String> = RENAMED_ENV_VARS
+        .iter()
+        .filter(|(old, _)| env::var_os(old).is_some())
+        .map(|(old, new)| format!("{old} (renamed to {new})"))
+        .collect();
+    if !stale.is_empty() {
+        anyhow::bail!(
+            "refusing to start: removed environment variable(s) still set: {}. \
+             Rename them in your deployment to the LIFTLOG_-prefixed names.",
+            stale.join(", ")
+        );
+    }
+    Ok(())
+}
+
 impl Config {
     pub fn from_env() -> anyhow::Result<Self> {
+        reject_legacy_env_vars()?;
         Ok(Self {
             database_url: env::var("DATABASE_URL")
                 .unwrap_or_else(|_| "sqlite:liftlog.sqlite3?mode=rwc".to_string()),
@@ -84,5 +112,44 @@ mod tests {
         }
         let config = Config::from_env().expect("from_env should succeed");
         assert_eq!(config.bind, "127.0.0.1:9137".parse().unwrap());
+    }
+
+    #[test]
+    fn from_env_rejects_legacy_bind() {
+        // A pre-prefix name still set means the deployment wasn't migrated;
+        // startup must fail with a message naming both the old and new var.
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::set_var("BIND", "0.0.0.0:8080");
+        }
+        assert!(
+            Config::from_env().is_err(),
+            "legacy BIND should fail startup"
+        );
+        let msg = reject_legacy_env_vars().unwrap_err().to_string();
+        assert!(msg.contains("BIND"), "got: {msg}");
+        assert!(msg.contains("LIFTLOG_BIND"), "got: {msg}");
+    }
+
+    #[test]
+    fn from_env_rejects_legacy_log_format() {
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::set_var("LOG_FORMAT", "json");
+        }
+        assert!(
+            Config::from_env().is_err(),
+            "legacy LOG_FORMAT should fail startup"
+        );
+        let msg = reject_legacy_env_vars().unwrap_err().to_string();
+        assert!(msg.contains("LOG_FORMAT"), "got: {msg}");
+        assert!(msg.contains("LIFTLOG_LOG_FORMAT"), "got: {msg}");
+    }
+
+    #[test]
+    fn reject_legacy_env_vars_passes_when_clean() {
+        // A process with no legacy names set (nextest isolates each test) is
+        // accepted.
+        reject_legacy_env_vars().expect("no legacy vars should pass");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ enum LogFormat {
 #[command(name = "liftlog")]
 struct Args {
     /// Log output format
-    #[arg(long, env = "LOG_FORMAT", default_value = "full")]
+    #[arg(long, env = "LIFTLOG_LOG_FORMAT", default_value = "full")]
     log_format: LogFormat,
 }
 

--- a/tests/e2e/steps/fixtures.js
+++ b/tests/e2e/steps/fixtures.js
@@ -50,7 +50,7 @@ export const test = base.extend({
         env: {
           ...process.env,
           DATABASE_URL: `sqlite:${dbRel}?mode=rwc`,
-          BIND: `127.0.0.1:${port}`,
+          LIFTLOG_BIND: `127.0.0.1:${port}`,
           RUST_LOG: 'liftlog=warn',
         },
         stdio: ['ignore', 'pipe', 'pipe'],


### PR DESCRIPTION
## Summary

Namespaces the two app-specific runtime environment variables under a `LIFTLOG_` prefix, and adds a startup guard that fails loudly when the old names are still set.

- `BIND` → `LIFTLOG_BIND`
- `LOG_FORMAT` → `LIFTLOG_LOG_FORMAT`

Ecosystem-standard variables (`RUST_LOG`, `NO_COLOR`) and `DATABASE_URL` are intentionally left unchanged to preserve conventional behavior and avoid surprising operators.

## Legacy-name detection

`reject_legacy_env_vars()` runs inside `Config::from_env()`. If a pre-prefix name (`BIND`, `LOG_FORMAT`) is still present in the environment, the server **refuses to start** and names the replacement — an un-migrated deployment fails loudly instead of silently ignoring the stale value.

## Changes

- `src/config.rs` — read `LIFTLOG_BIND`; startup guard rejecting legacy names; updated doc comment, error message, and tests
- `src/main.rs` — clap `#[arg(env = "LIFTLOG_LOG_FORMAT")]`
- `Dockerfile` — `ENV LIFTLOG_BIND=0.0.0.0:8080`
- `README.md` — env var table + migration note
- `CLAUDE.md` — dev server note
- `tests/e2e/steps/fixtures.js` — e2e server spawn env

## Breaking change

Existing deployments must rename `BIND` and `LOG_FORMAT` in their environment / compose files to `LIFTLOG_BIND` and `LIFTLOG_LOG_FORMAT`. Leaving the old names set now blocks startup.

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo nextest run` ✅ (313 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)