### PR TITLE
fix(auth): authorize exercise_id against the caller

### DIFF
--- a/src/handlers/stats.rs
+++ b/src/handlers/stats.rs
@@ -194,11 +194,13 @@ pub async fn exercise_stats(
     auth_user: AuthUser,
     Path(exercise_id): Path<String>,
 ) -> Result<Response> {
+    // The history/PR/metrics queries below are all scoped by `auth_user.id`, but
+    // the exercise record itself is rendered, so fetching it unscoped disclosed
+    // another user's exercise name and category.
     let exercise = state
         .exercise_repo
-        .find_by_id(&exercise_id)
-        .await?
-        .ok_or_else(|| AppError::NotFound("Exercise not found".to_string()))?;
+        .find_owned(&exercise_id, &auth_user.id)
+        .await?;
 
     let history = state
         .workout_repo

--- a/src/handlers/workouts.rs
+++ b/src/handlers/workouts.rs
@@ -239,6 +239,14 @@ pub async fn add_log(
         .find_owned_session(&session_id, &auth_user.id)
         .await?;
 
+    // `exercise_id` arrives from the form body, so owning the session is not
+    // enough — without this a caller could attach a log to another user's
+    // exercise, which the UI's own <select> would never offer.
+    state
+        .exercise_repo
+        .find_owned(&form.exercise_id, &auth_user.id)
+        .await?;
+
     let set_number = state
         .workout_repo
         .get_next_set_number(&session_id, &form.exercise_id)

--- a/tests/stats_test.rs
+++ b/tests/stats_test.rs
@@ -455,3 +455,42 @@ async fn test_exercise_stats_chart_pr_dots_match_expected_indices() {
     assert_eq!(pr_count, 3, "expected 3 PR dots, body=\n{body_str}");
     assert_eq!(plain_count, 2);
 }
+
+#[tokio::test]
+async fn test_exercise_stats_rejects_exercise_owned_by_another_user() {
+    // The history, PR and metrics queries are scoped by the caller, but the
+    // exercise record itself is rendered into the page — fetching it unscoped
+    // disclosed another user's exercise name and category.
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_session(pool.clone());
+
+    let snooper = common::create_test_user(&pool, "snooper", "password123", UserRole::User).await;
+    let victim = common::create_test_user(&pool, "victim", "password123", UserRole::User).await;
+
+    let session_cookie = common::create_session_cookie(&pool, &snooper).await;
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    let victim_exercise =
+        common::create_test_exercise(&pool, &victim.id, "Victim Deadlift", "back").await;
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .uri(format!("/stats/exercise/{}", victim_exercise.id))
+                .header(header::COOKIE, &cookie_header)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_str = String::from_utf8_lossy(&body);
+    assert!(
+        !body_str.contains("Victim Deadlift"),
+        "the other user's exercise name must not be disclosed, body=\n{body_str}"
+    );
+}

--- a/tests/workout_test.rs
+++ b/tests/workout_test.rs
@@ -546,6 +546,62 @@ async fn test_add_log_success() {
 }
 
 #[tokio::test]
+async fn test_add_log_rejects_exercise_owned_by_another_user() {
+    // Owning the workout session does not entitle the caller to reference an
+    // exercise belonging to somebody else: `exercise_id` comes straight from the
+    // form body, so it has to be authorized independently of the session.
+    let pool = common::setup_test_db();
+    let test_app = common::create_test_app_with_session(pool.clone());
+
+    let attacker = common::create_test_user(&pool, "attacker", "password123", UserRole::User).await;
+    let victim = common::create_test_user(&pool, "victim", "password123", UserRole::User).await;
+
+    let session_cookie = common::create_session_cookie(&pool, &attacker).await;
+    let cookie_header = common::extract_cookie_header(&session_cookie);
+
+    let victim_exercise =
+        common::create_test_exercise(&pool, &victim.id, "Victim Squat", "legs").await;
+    let workout = common::create_test_workout(
+        &pool,
+        &attacker.id,
+        chrono::NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
+        None,
+    )
+    .await;
+
+    let response = test_app
+        .router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/workouts/{}/logs", workout.id))
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .header(header::COOKIE, &cookie_header)
+                .body(Body::from(format!(
+                    "exercise_id={}&reps=10&weight=100&rpe=8",
+                    victim_exercise.id
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+    // The write must not have happened at all, not merely been reported as denied.
+    let workout_repo = WorkoutRepository::new(pool);
+    let logs = workout_repo
+        .find_logs_by_session_with_pr(&workout.id, &attacker.id)
+        .await
+        .unwrap();
+    assert!(
+        logs.is_empty(),
+        "no log should have been created, got {} log(s)",
+        logs.len()
+    );
+}
+
+#[tokio::test]
 #[allow(clippy::float_cmp, reason = "exact-value test assertion")]
 async fn test_add_log_accepts_fractional_weight() {
     let pool = common::setup_test_db();


### PR DESCRIPTION
Follow-up to #131, which found this incidentally during its final review round.

Two routes accepted an exercise identifier from the request and never checked it belonged to the caller.

| Route | Gap |
|---|---|
| `POST /workouts/{id}/logs` (`add_log`) | Verified session ownership, but `exercise_id` arrives from the form body and was never authorized. A user could attach a workout log to another user's exercise — the write returned `303` and succeeded. |
| `GET /stats/exercise/{id}` (`exercise_stats`) | Fetched the exercise with an unscoped `find_by_id`. The history, PR and metrics queries are all correctly scoped by the caller, but the exercise record itself is rendered, so its name and category were disclosed to anyone knowing the id. |

Both now go through `ExerciseRepository::find_owned`, the primitive the exercise edit/update/delete handlers already use, which yields `403` for someone else's exercise and `404` for one that does not exist.

## Why this breaks nothing

Exercises are fully private per user — `find_available_for_user` filters on `user_id = ?`, with no shared or global library — so `find_owned` is the correct check rather than an over-restriction. The add-log `<select>` is populated from that same owner-scoped query, so the legitimate UI path could never submit an id this rejects.

`UpdateWorkoutLog` carries no `exercise_id`, so `update_log` cannot reassign a log's exercise; `add_log` was the only affected write.

## Verification

Each fix has a regression test that was verified to fail when the check is reverted:

- `test_add_log_rejects_exercise_owned_by_another_user` — `left: 303, right: 403` under mutation, and it asserts no log row was created rather than only checking the status.
- `test_exercise_stats_rejects_exercise_owned_by_another_user` — `left: 200, right: 403` under mutation, and it asserts the victim's exercise name is absent from the body.

542 tests pass; `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings` are clean.

## Note

`find_owned` returns `403` for an exercise that exists but belongs to someone else, distinguishing it from the `404` for one that does not exist. That is a weak existence oracle over unguessable UUIDv4 ids, and it matches the behaviour the exercise edit/delete handlers already have. Collapsing both to `404` would be a broader behaviour change across those handlers and their tests, so it is left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
