### PR TITLE
refactor(auth): build a request's AuditContext once

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -82,6 +82,15 @@ impl FromRequestParts<AppState> for AuditContext {
         parts: &mut Parts,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
+        // `sliding_session_middleware` already built one for every request that
+        // carried a session token, so reuse it rather than recomputing the same
+        // client-IP resolution and `User-Agent` truncation. The fallback is not
+        // dead: the anonymous routes that take this extractor (login and first-user
+        // setup) have no session token, so the middleware never built one for them.
+        if let Some(ctx) = parts.extensions.get::<Self>() {
+            return Ok(ctx.clone());
+        }
+
         Ok(Self::from_request_pieces(
             &parts.extensions,
             &parts.headers,
@@ -236,6 +245,61 @@ mod tests {
 
         let got = ctx.user_agent.expect("user agent should be present");
         assert!(got.chars().count() <= MAX_USER_AGENT_LEN);
+    }
+
+    /// The extractor must reuse the context `sliding_session_middleware`
+    /// already put in the request extensions, not rebuild its own. Proven by
+    /// making the two disagree: the stored context carries values the request's
+    /// own headers and URI would never produce, so a rebuild is detectable.
+    #[tokio::test]
+    async fn audit_context_extractor_prefers_the_one_the_middleware_built() {
+        let pool = crate::db::create_memory_pool().expect("memory pool");
+        let state = AppState {
+            user_repo: crate::repositories::UserRepository::new(pool.clone()),
+            exercise_repo: crate::repositories::ExerciseRepository::new(pool.clone()),
+            workout_repo: crate::repositories::WorkoutRepository::new(pool.clone()),
+            session_repo: crate::repositories::SessionRepository::new(pool),
+            login_rate_limiter: std::sync::Arc::new(crate::rate_limit::RateLimiter::new(
+                5,
+                std::time::Duration::from_secs(60),
+            )),
+            trusted_proxy_header: TrustedProxyHeader::None,
+            trusted_proxies: std::sync::Arc::new(vec![]),
+            cookie_secure: false,
+            hsts_max_age: 0,
+            hsts_include_subdomains: false,
+            log_salt: std::sync::Arc::new([0u8; 32]),
+        };
+
+        let stored = AuditContext {
+            client_ip: "203.0.113.7".parse().unwrap(),
+            user_agent: Some("middleware-built".to_string()),
+            path: "/built-by-middleware".to_string(),
+        };
+
+        let request = axum::http::Request::builder()
+            .uri("/rebuilt-by-extractor")
+            .header(axum::http::header::USER_AGENT, "rebuilt-by-extractor")
+            .extension(stored)
+            .body(())
+            .unwrap();
+        let (mut parts, ()) = request.into_parts();
+
+        let ctx = AuditContext::from_request_parts(&mut parts, &state)
+            .await
+            .expect("extractor is infallible");
+
+        assert_eq!(ctx.path, "/built-by-middleware", "path was rebuilt");
+        assert_eq!(
+            ctx.user_agent.as_deref(),
+            Some("middleware-built"),
+            "user_agent was rebuilt"
+        );
+        assert_eq!(
+            ctx.client_ip.to_string(),
+            "203.0.113.7",
+            "client_ip was rebuilt"
+        );
     }
 
     #[test]

--- a/src/middleware/auth.rs
+++ b/src/middleware/auth.rs
@@ -128,6 +128,12 @@ pub async fn sliding_session_middleware(
                 tracing::warn!(error = ?e, "sliding_session_middleware: validate_and_touch failed");
             }
         }
+
+        // Handlers that emit their own audit events (logout, password change,
+        // "log out other devices", admin user delete) take an `AuditContext`
+        // extractor. Hand them the one already built here so a request has a
+        // single audit context rather than one per consumer.
+        request.extensions_mut().insert(ctx);
     }
 
     let mut response = next.run(request).await;


### PR DESCRIPTION
Follow-up to #131, which deferred this as a low-priority cleanup.

`sliding_session_middleware` builds an `AuditContext` for every request carrying a session token. The `FromRequestParts` extractor then built a second, identical one for the four authenticated handlers that emit their own audit events — `logout`, `change_password`, `logout_others` and the admin `delete_user` — repeating the client-IP resolution and `User-Agent` truncation once per request.

The middleware now stores its context in the request extensions and the extractor reuses it, so a request has one audit context rather than one per consumer.

## The fallback is not dead code

The extractor keeps the rebuild path, and it stays reachable: the two anonymous routes that take this extractor — `login_submit` and the first-user `setup_submit` — carry no session token, so the middleware never builds a context for them. Both paths are exercised by the existing suite.

## No behaviour change

The two contexts were always built from the same inputs, so nothing observable differs. That makes the change unprovable by a black-box test, so the new unit test attacks it directly: it stores a context whose `path`, `user_agent` and `client_ip` the request's own URI and headers would never produce, then asserts the extractor returns the stored values. Removing the extension lookup fails it with `left: "/rebuilt-by-extractor", right: "/built-by-middleware"`.

542 tests pass; `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
