### PR TITLE
chore(deps): add rust-toolchain ecosystem, normalise dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,46 +1,41 @@
 version: 2
 updates:
-  - package-ecosystem: cargo
-    directory: /
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: weekly
+      interval: "weekly"
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 10
-    groups:
-      cargo:
-        patterns:
-          - "*"
-        update-types:
-          - minor
-          - patch
-
-  - package-ecosystem: docker
-    directory: /
-    schedule:
-      interval: weekly
-    cooldown:
-      default-days: 7
-    open-pull-requests-limit: 5
-    groups:
-      docker:
-        patterns:
-          - "*"
-        update-types:
-          - minor
-          - patch
-
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly
-    cooldown:
-      default-days: 7
-    open-pull-requests-limit: 5
     groups:
       github-actions:
         patterns:
           - "*"
-        update-types:
-          - minor
-          - patch
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      cargo:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "rust-toolchain"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      docker:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Adds a `rust-toolchain` ecosystem so Dependabot proposes compiler bumps for `rust-toolchain.toml` (currently pinned at `1.96.0`), on the same weekly schedule and 7-day cooldown as everything else. No group — there is only ever one entry.

Pinning the toolchain means nothing moves it by accident, which also means nothing moves it at all. This closes that gap.

## Also

Normalises the file to the shape now shared across the Rust repos:

- quoted scalars for `package-ecosystem` / `directory` / `interval`
- fixed ecosystem order: `github-actions` → `cargo` → `rust-toolchain` → `docker`
- drops `open-pull-requests-limit` (3 occurrences) — it never bound, since every ecosystem groups into a single PR
- drops the `update-types: [minor, patch]` filter (3 occurrences)

Note the last one is a behaviour change, not just cleanup: major bumps for crates, base images and actions will now be proposed instead of silently withheld.

MSRV (`rust-version` in `Cargo.toml`) is untouched and stays managed separately from the toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)