### PR TITLE
ci(workflows): one run per ref at a time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [main]
 
+# One run per ref at a time. A newer push supersedes the run it interrupted;
+# a tag does not — a tagged build publishes one specific version and nothing
+# should quietly cancel it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
     tags: ["v*"]
 
+# One run per ref at a time. A newer push supersedes the run it interrupted;
+# a tag does not — a tagged build publishes one specific version and nothing
+# should quietly cancel it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Merging two pull requests in quick succession starts two multi-arch image builds in parallel, both racing to push the same `:main` tag. Whichever finishes last wins, which is not necessarily whichever commit is newest — an older build could overwrite a newer one.

Neither `docker.yml` nor `ci.yml` had a concurrency group. Both get the same block:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
```

Superseding is right for a branch, where `:main` means "latest" by definition. It is wrong for a release: a tagged build publishes one specific version, and nothing should quietly cancel it — hence the condition rather than a flat `cancel-in-progress: true`.

`ci.yml` never sees a tag ref today, so the condition is a no-op there. That is deliberate: one spelling of the policy in every workflow means a tag trigger added later cannot silently inherit the wrong cancellation semantics.

Part of a sweep applying the identical block across every repository that publishes an image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)