### PR TITLE
ci(workflows): name the rolling tag with one directive shape

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=ref,event=branch
+            type=raw,value={{branch}},enable={{is_default_branch}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
       - name: Get version


### PR DESCRIPTION
`type=ref,event=branch` derives the rolling tag from the branch name implicitly. That works, but it **cannot express a rolling tag that is not named after a branch** — `:nightly`, which comics and tiddlywiki5 publish. So the fleet carried two different mechanisms for the same concept.

One directive shape covers both:

```yaml
type=raw,value={{branch}},enable={{is_default_branch}}   # tag follows the default branch
type=raw,value=nightly,enable={{is_default_branch}}      # tag is a literal
```

`type=raw`'s value accepts metadata-action's template expressions, so `{{branch}}` keeps the tag derived from the default branch rather than hard-coding `main`. Only the value slot differs between the two camps; the directive is otherwise identical in every repository.

### No behaviour change

This workflow triggers only on pushes to the default branch and on tags, so `event=branch` only ever fired on the default branch and produced `:main` — exactly what `{{branch}}` guarded by `is_default_branch` produces. The published tag is byte-identical.

One difference is deliberate: should a non-default branch ever be added to the push trigger, `event=branch` would have silently published `:that-branch`. `is_default_branch` will not.

### Fleet after this sweep

| rolling tag | repos |
|---|---|
| `{{branch}}` → `:main` | liftlog, noadd, noda, pingward, rdrs, lur |
| literal `nightly` | comics, tiddlywiki5 |

Separate from the `:latest` cleanup (comics#379, tiddlywiki5#25), which touches the release tags rather than the rolling one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
