### PR TITLE
refactor: drop DB columns the presentation layer discards

### DIFF
--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -10,7 +10,7 @@ use crate::audit::{self, AuditContext};
 use crate::error::{AppError, Result};
 use crate::middleware::auth::ValidatedSession;
 use crate::middleware::{AdminUser, AuthUser, SuppressSessionRefresh};
-use crate::models::{CreateUser, LoginCredentials, User, UserRole};
+use crate::models::{CreateUser, LoginCredentials, UserListItem, UserRole};
 use crate::session::{create_session_cookie, remove_session_cookie, token_fingerprint};
 use crate::state::AppState;
 
@@ -37,7 +37,7 @@ struct NewUserTemplate {
 #[template(path = "auth/users.html")]
 struct UsersListTemplate {
     user: AuthUser,
-    users: Vec<User>,
+    users: Vec<UserListItem>,
 }
 
 /// Returns the validation error message, or `None` if the form is valid.

--- a/src/models/exercise_session_metric.rs
+++ b/src/models/exercise_session_metric.rs
@@ -8,7 +8,6 @@ use super::FromSqliteRow;
 /// Returned by `WorkoutRepository::get_session_metrics_for_exercise`.
 #[derive(Debug, Clone)]
 pub struct ExerciseSessionMetric {
-    pub session_id: String,
     pub date: NaiveDate,
     pub top_weight: f64,
     pub top_reps: i32,
@@ -18,7 +17,6 @@ pub struct ExerciseSessionMetric {
 impl FromSqliteRow for ExerciseSessionMetric {
     fn from_row(row: &Row) -> rusqlite::Result<Self> {
         Ok(Self {
-            session_id: row.get("session_id")?,
             date: row.get("date")?,
             top_weight: row.get("top_weight")?,
             top_reps: row.get("top_reps")?,
@@ -31,7 +29,6 @@ impl FromSqliteRow for ExerciseSessionMetric {
 /// Serialized into the page as JSON for the client-side switch handler.
 #[derive(Debug, Clone, Serialize)]
 pub struct ChartPoint {
-    pub session_id: String,
     pub date: NaiveDate,
     pub top_weight: f64,
     pub top_reps: i32,
@@ -42,7 +39,6 @@ pub struct ChartPoint {
 impl ChartPoint {
     pub fn from_metric(m: &ExerciseSessionMetric) -> Self {
         Self {
-            session_id: m.session_id.clone(),
             date: m.date,
             top_weight: m.top_weight,
             top_reps: m.top_reps,
@@ -60,7 +56,6 @@ mod tests {
     #[allow(clippy::float_cmp, reason = "exact-value test assertion")]
     fn chart_point_from_metric_computes_epley_e1rm() {
         let metric = ExerciseSessionMetric {
-            session_id: "s1".into(),
             date: NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
             top_weight: 100.0,
             top_reps: 6,
@@ -69,7 +64,6 @@ mod tests {
         let point = ChartPoint::from_metric(&metric);
         // Epley: 100 * (1 + 6/30) = 100 * 1.2 = 120.0
         assert!((point.e1rm - 120.0).abs() < 1e-9);
-        assert_eq!(point.session_id, "s1");
         assert_eq!(point.top_weight, 100.0);
         assert_eq!(point.top_reps, 6);
         assert_eq!(point.volume, 600.0);
@@ -78,7 +72,6 @@ mod tests {
     #[test]
     fn chart_point_e1rm_for_single_rep_equals_top_weight() {
         let metric = ExerciseSessionMetric {
-            session_id: "s2".into(),
             date: NaiveDate::from_ymd_opt(2024, 1, 16).unwrap(),
             top_weight: 140.0,
             top_reps: 0,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -10,6 +10,6 @@ pub use exercise::{CreateExercise, Exercise, UpdateExercise};
 pub use exercise_session_metric::{ChartPoint, ExerciseSessionMetric};
 pub use from_row::FromSqliteRow;
 pub use personal_record::{DynamicPR, LastExerciseWeight};
-pub use user::{CreateUser, LoginCredentials, User, UserRole};
+pub use user::{CreateUser, LoginCredentials, User, UserListItem, UserRole};
 pub use workout_log::{CreateWorkoutLog, UpdateWorkoutLog, WorkoutLog, WorkoutLogWithExercise};
 pub use workout_session::{CreateWorkoutSession, WorkoutSession};

--- a/src/models/personal_record.rs
+++ b/src/models/personal_record.rs
@@ -28,7 +28,6 @@ impl FromSqliteRow for DynamicPR {
 #[derive(Debug, Clone, Serialize)]
 pub struct LastExerciseWeight {
     pub exercise_id: String,
-    pub exercise_name: String,
     pub weight: f64,
     pub rpe: Option<i32>,
     pub logged_at: DateTime<Utc>,
@@ -38,7 +37,6 @@ impl FromSqliteRow for LastExerciseWeight {
     fn from_row(row: &Row) -> rusqlite::Result<Self> {
         Ok(Self {
             exercise_id: row.get("exercise_id")?,
-            exercise_name: row.get("exercise_name")?,
             weight: row.get("weight")?,
             rpe: row.get("rpe")?,
             logged_at: row.get("logged_at")?,

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -61,6 +61,29 @@ impl FromSqliteRow for User {
     }
 }
 
+/// Row shape for the admin users list. Deliberately omits `password_hash` —
+/// the list never renders it, and pulling every user's Argon2 hash into a
+/// template context is exposure with no upside.
+#[derive(Debug, Clone)]
+pub struct UserListItem {
+    pub id: String,
+    pub username: String,
+    pub role: UserRole,
+    pub created_at: DateTime<Utc>,
+}
+
+impl FromSqliteRow for UserListItem {
+    fn from_row(row: &Row) -> rusqlite::Result<Self> {
+        let role_str: String = row.get("role")?;
+        Ok(Self {
+            id: row.get("id")?,
+            username: row.get("username")?,
+            role: UserRole::parse(&role_str),
+            created_at: row.get("created_at")?,
+        })
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct CreateUser {
     pub username: String,

--- a/src/repositories/user_repo.rs
+++ b/src/repositories/user_repo.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 
 use crate::db::DbPool;
 use crate::error::{AppError, Result};
-use crate::models::{FromSqliteRow, User, UserRole};
+use crate::models::{FromSqliteRow, User, UserListItem, UserRole};
 
 #[derive(Clone)]
 pub struct UserRepository {
@@ -55,13 +55,17 @@ impl UserRepository {
         .await?
     }
 
-    pub async fn find_all(&self) -> Result<Vec<User>> {
+    /// Columns are listed explicitly rather than `SELECT *` so `password_hash`
+    /// never leaves the DB for a read that only feeds the users list.
+    pub async fn find_all(&self) -> Result<Vec<UserListItem>> {
         let pool = self.pool.clone();
         tokio::task::spawn_blocking(move || {
             let conn = pool.get()?;
-            let mut stmt = conn.prepare("SELECT * FROM users ORDER BY created_at DESC")?;
+            let mut stmt = conn.prepare(
+                "SELECT id, username, role, created_at FROM users ORDER BY created_at DESC",
+            )?;
             let users = stmt
-                .query_map([], User::from_row)?
+                .query_map([], UserListItem::from_row)?
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             Ok(users)
         })

--- a/src/repositories/workout_repo.rs
+++ b/src/repositories/workout_repo.rs
@@ -373,13 +373,12 @@ impl WorkoutRepository {
         tokio::task::spawn_blocking(move || {
             let conn = pool.get()?;
             let mut stmt = conn.prepare(
-                "SELECT wl.exercise_id, e.name as exercise_name,
+                "SELECT wl.exercise_id,
                         wl.weight as weight,
                         wl.rpe as rpe,
                         MAX(wl.created_at) as logged_at
                  FROM workout_logs wl
                  JOIN workout_sessions ws ON wl.session_id = ws.id
-                 JOIN exercises e ON wl.exercise_id = e.id
                  WHERE ws.user_id = ?
                  GROUP BY wl.exercise_id
                  ORDER BY logged_at DESC",
@@ -437,7 +436,6 @@ impl WorkoutRepository {
             let conn = pool.get()?;
             let mut stmt = conn.prepare(
                 "SELECT
-                     ws.id   AS session_id,
                      ws.date AS date,
                      MAX(wl.weight) AS top_weight,
                      (SELECT wl2.reps
@@ -1476,7 +1474,6 @@ mod tests {
 
         assert_eq!(metrics.len(), 1);
         let m = &metrics[0];
-        assert_eq!(m.session_id, session.id);
         assert_eq!(m.date, date);
         assert!((m.top_weight - 110.0).abs() < 1e-9);
         assert_eq!(m.top_reps, 8);


### PR DESCRIPTION
Three reads pulled columns out of SQLite that nothing downstream consumed. Found by comparing every repository `SELECT` against the model structs and the Askama templates that render them.

## Changes

**1. The admin users list no longer loads password hashes.** `UserRepository::find_all()` used `SELECT *` and returned `Vec<User>`, so every user's Argon2 hash landed in the render context for `templates/auth/users.html` — which only renders `username`, `role`, `created_at` and `id`. Askama never emitted the hash, so this was not a leak, but it was avoidable exposure. Replaced with a `UserListItem` projection and an explicit column list. `find_all()` had exactly one production caller.

**2. `ChartPoint.session_id` is gone.** It was serialized into `chart_data_json` and embedded in the exercise stats page, but the client-side chart switcher only reads `date`, `top_weight`, `top_reps`, `volume` and `e1rm`. Removing it left `ExerciseSessionMetric.session_id` without readers, so `ws.id AS session_id` comes out of the query as well — `GROUP BY ws.id` does not require it in the select list.

**3. `LastExerciseWeight.exercise_name` is gone,** along with the `JOIN exercises` it required. The workout page builds its `exerciseLastWeights` map from `exercise_id`, `weight`, `rpe` and `logged_at` only. Dropping the inner join does not change the result set: `workout_logs.exercise_id` is a `FOREIGN KEY ... ON DELETE RESTRICT`, so a matching exercise row always exists.

## Deliberately left alone

`Exercise.user_id`, `WorkoutSession.created_at`, `WorkoutLog.created_at` and `WorkoutLogWithExercise.session_id` are also unread by any template, but they are byproducts of `SELECT *` with no rendering or transfer cost. Removing them would mean either rewriting those queries or splitting the model types away from the table schema — noise outweighing the benefit.

## Verification

- `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings`: clean
- `cargo nextest run`: 544 passed, 0 skipped
- Three test assertions on the removed fields were dropped
- No template changes were needed; Askama's compile-time field checking covers the three affected pages
- The E2E suite could not be run locally (Playwright browser binaries are not installed on this machine), so CI is the first run of it against these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)