### PR TITLE
refactor: clear the dead and stale #[allow(dead_code)] sites

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1,10 +1,8 @@
-use r2d2::{Pool, PooledConnection};
+use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
 use std::path::Path;
 
 pub type DbPool = Pool<SqliteConnectionManager>;
-#[allow(dead_code)]
-pub type DbConnection = PooledConnection<SqliteConnectionManager>;
 
 pub fn create_pool(database_url: &str) -> Result<DbPool, r2d2::Error> {
     let path = database_url.strip_prefix("sqlite:").unwrap_or(database_url);

--- a/src/models/workout_session.rs
+++ b/src/models/workout_session.rs
@@ -35,10 +35,3 @@ pub struct CreateWorkoutSession {
     pub date: NaiveDate,
     pub notes: Option<String>,
 }
-
-#[allow(dead_code)]
-#[derive(Debug, Deserialize)]
-pub struct UpdateWorkoutSession {
-    pub date: Option<NaiveDate>,
-    pub notes: Option<String>,
-}

--- a/src/repositories/exercise_repo.rs
+++ b/src/repositories/exercise_repo.rs
@@ -27,36 +27,6 @@ impl ExerciseRepository {
         .await?
     }
 
-    #[allow(dead_code)]
-    pub async fn find_all(&self) -> Result<Vec<Exercise>> {
-        let pool = self.pool.clone();
-        tokio::task::spawn_blocking(move || {
-            let conn = pool.get()?;
-            let mut stmt = conn.prepare("SELECT * FROM exercises ORDER BY category, name")?;
-            let exercises = stmt
-                .query_map([], Exercise::from_row)?
-                .collect::<rusqlite::Result<Vec<_>>>()?;
-            Ok(exercises)
-        })
-        .await?
-    }
-
-    #[allow(dead_code)]
-    pub async fn find_by_category(&self, category: &str) -> Result<Vec<Exercise>> {
-        let pool = self.pool.clone();
-        let category = category.to_string();
-        tokio::task::spawn_blocking(move || {
-            let conn = pool.get()?;
-            let mut stmt =
-                conn.prepare("SELECT * FROM exercises WHERE category = ? ORDER BY name")?;
-            let exercises = stmt
-                .query_map([&category], Exercise::from_row)?
-                .collect::<rusqlite::Result<Vec<_>>>()?;
-            Ok(exercises)
-        })
-        .await?
-    }
-
     /// Fetch an exercise owned by `user_id`. Returns `NotFound` if no such row,
     /// `Forbidden` if it exists but belongs to another user.
     pub async fn find_owned(&self, id: &str, user_id: &str) -> Result<Exercise> {

--- a/src/repositories/user_repo.rs
+++ b/src/repositories/user_repo.rs
@@ -30,7 +30,6 @@ impl UserRepository {
         .await?
     }
 
-    #[allow(dead_code)]
     pub async fn find_by_id(&self, id: &str) -> Result<Option<User>> {
         let pool = self.pool.clone();
         let id = id.to_string();

--- a/src/repositories/workout_repo.rs
+++ b/src/repositories/workout_repo.rs
@@ -84,22 +84,6 @@ impl WorkoutRepository {
         .await?
     }
 
-    #[allow(dead_code)]
-    pub async fn find_sessions_by_user(&self, user_id: &str) -> Result<Vec<WorkoutSession>> {
-        let pool = self.pool.clone();
-        let user_id = user_id.to_string();
-        tokio::task::spawn_blocking(move || {
-            let conn = pool.get()?;
-            let mut stmt = conn
-                .prepare("SELECT * FROM workout_sessions WHERE user_id = ? ORDER BY date DESC")?;
-            let sessions = stmt
-                .query_map([&user_id], WorkoutSession::from_row)?
-                .collect::<rusqlite::Result<Vec<_>>>()?;
-            Ok(sessions)
-        })
-        .await?
-    }
-
     pub async fn find_sessions_by_user_paginated(
         &self,
         user_id: &str,
@@ -264,7 +248,6 @@ impl WorkoutRepository {
         .await?
     }
 
-    #[allow(dead_code)]
     pub async fn find_log_by_id(&self, id: &str) -> Result<Option<WorkoutLog>> {
         let pool = self.pool.clone();
         let id = id.to_string();
@@ -762,7 +745,10 @@ mod tests {
         repo.create_session("user1", date2, None).await.unwrap();
         repo.create_session("user1", date3, None).await.unwrap();
 
-        let sessions = repo.find_sessions_by_user("user1").await.unwrap();
+        let sessions = repo
+            .find_sessions_by_user_paginated("user1", 10, 0)
+            .await
+            .unwrap();
 
         assert_eq!(sessions.len(), 3);
         // Should be ordered by date DESC


### PR DESCRIPTION
Closes #142.

Acts on categories **A** and **B** from the audit. Every call site in the issue was re-verified against `main` at `617d407` — all line numbers and callers still held.

## A. Genuinely dead — removed

| Item | Location |
| --- | --- |
| `UpdateWorkoutSession` | `src/models/workout_session.rs` |
| `ExerciseRepository::find_all` | `src/repositories/exercise_repo.rs` |
| `ExerciseRepository::find_by_category` | `src/repositories/exercise_repo.rs` |
| `DbConnection` type alias | `src/db.rs` |
| `WorkoutRepository::find_sessions_by_user` | `src/repositories/workout_repo.rs` |

Removing `DbConnection` also strands the `PooledConnection` import — it was pulled in solely for that alias — so it goes too. `DbPool` keeps using `Pool` directly.

One thing worth flagging for reviewers: `.find_all(` does have live callers (`handlers/auth.rs:282`), but those are `UserRepository::find_all`, a different method that carries no `#[allow]`. Only the `ExerciseRepository` pair is dead. Same shape for `.find_by_id(` — `handlers/workouts.rs:307` is `ExerciseRepository`'s, while the `UserRepository` one is used at `:435`.

## B. Stale attribute — function kept, `#[allow]` deleted

| Item | Live caller |
| --- | --- |
| `UserRepository::find_by_id` | `handlers/workouts.rs:435` — resolves the owner's username for a shared workout |
| `WorkoutRepository::find_log_by_id` | `handlers/workouts.rs:297` — session-ownership check before editing a log |

`cargo clippy --all-targets -- -D warnings` passes with both attributes gone. That is the check that matters here: it confirms they were suppressing a lint that no longer fires.

## C. Untouched

`run_migrations_for_tests` and `create_memory_pool` stay — used across the crate boundary by integration tests, which the bin target's dead-code analysis can't see. `AppError::Unauthorized` / `::Validation` are left as-is, pending the separate call the issue invites.

`#[allow(dead_code)]` count: **11 → 4**, and each survivor now has a stated reason.

## Deviation from the issue

The issue called for deleting `test_find_sessions_by_user_ordered` along with the function it exercises. I checked the paginated test first: it only asserts page **lengths**, never ordering. So that test is the only assertion anywhere on `ORDER BY date DESC`, and deleting it would leave the production query's ordering untested.

Instead of deleting it, the test is repointed at `find_sessions_by_user_paginated` — same `ORDER BY date DESC` — with its assertions unchanged. Net effect is slightly more coverage than before, on the path that actually ships. Happy to delete it outright if you'd rather keep strictly to the issue.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — exit 0, no warnings
- `cargo nextest run` — **544 passed**, 0 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)