### PR TITLE
refactor(error): drop the never-constructed AppError variants

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -15,19 +15,11 @@ pub enum AppError {
     #[error("Not found: {0}")]
     NotFound(String),
 
-    #[error("Unauthorized")]
-    #[allow(dead_code)]
-    Unauthorized,
-
     #[error("Forbidden: {0}")]
     Forbidden(String),
 
     #[error("Bad request: {0}")]
     BadRequest(String),
-
-    #[error("Validation error: {0}")]
-    #[allow(dead_code)]
-    Validation(String),
 
     #[error("Internal error: {0}")]
     Internal(String),
@@ -66,11 +58,8 @@ impl IntoResponse for AppError {
                 )
             }
             AppError::NotFound(msg) => (StatusCode::NOT_FOUND, msg.clone()),
-            AppError::Unauthorized => (StatusCode::UNAUTHORIZED, "Unauthorized".to_string()),
             AppError::Forbidden(msg) => (StatusCode::FORBIDDEN, msg.clone()),
-            AppError::BadRequest(msg) | AppError::Validation(msg) => {
-                (StatusCode::BAD_REQUEST, msg.clone())
-            }
+            AppError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
             AppError::Internal(msg) => {
                 tracing::error!("Internal error: {}", msg);
                 (

--- a/tests/error_test.rs
+++ b/tests/error_test.rs
@@ -26,27 +26,11 @@ fn test_bad_request_returns_400() {
 }
 
 #[test]
-fn test_unauthorized_returns_401() {
-    let error = AppError::Unauthorized;
-    let response = error.into_response();
-
-    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
-}
-
-#[test]
 fn test_internal_returns_500() {
     let error = AppError::Internal("Something went wrong".to_string());
     let response = error.into_response();
 
     assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
-}
-
-#[test]
-fn test_validation_returns_400() {
-    let error = AppError::Validation("Invalid field".to_string());
-    let response = error.into_response();
-
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
 #[test]


### PR DESCRIPTION
Follow-up to #147, which deliberately left `AppError::Unauthorized` and `AppError::Validation` alone because #142 filed them under category C — *"arguably worth keeping for API completeness — open to a different call."* This makes that call: they go.

## Why they're removable

Neither is ever constructed outside tests, and that turns out to be **structural rather than incidental** — the app actively routes around both:

| Variant | Why nothing produces it |
| --- | --- |
| `Unauthorized` | `AuthUser`'s rejection is `AuthRedirect` (`middleware/auth.rs`), so an unauthenticated request gets a **302 to `/auth/login`**, never a bare 401. |
| `Validation` | Form errors re-render the template with `error: Option<String>`, following the POST→Redirect shape the handlers use. |

The "API completeness" argument doesn't apply either: this is a server-rendered HTML app with **no JSON API** (per `CLAUDE.md`), so there's no consumer for an error vocabulary richer than what the handlers actually emit.

## What changed

- Both variants removed from the `AppError` enum (9 variants → 7)
- Their `IntoResponse` arms removed. `Validation` shared an or-pattern with `BadRequest` that rustfmt had split across three lines; with the or-pattern gone it collapses to a single line, matching `NotFound` and `Forbidden` above it:

  ```rust
  -            AppError::BadRequest(msg) | AppError::Validation(msg) => {
  -                (StatusCode::BAD_REQUEST, msg.clone())
  -            }
  +            AppError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
  ```

- `test_unauthorized_returns_401` and `test_validation_returns_400` removed — they only ever exercised mappings unreachable in production

## Effect on the #142 audit

`#[allow(dead_code)]` count across the crate: **11 → 4** (after #147) → **2** now. Both survivors (`run_migrations_for_tests`, `create_memory_pool`) are used by integration tests across the crate boundary, which the bin target's dead-code analysis can't see.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — exit 0, no warnings
- `cargo nextest run` — **542 passed**, 0 skipped (544 before; the delta is exactly the two removed tests)

## Noted, not changed

`db.rs:57`'s `#[allow(dead_code)]` carries no comment explaining itself. #142 stated both category-C sites already had one, but only `migrations.rs:127` does (`// Used by integration tests`) — the comment inside `create_memory_pool` is about PRAGMA consistency, not about why the item looks dead. Out of scope here; happy to add it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)